### PR TITLE
NTRIP V2 get fix 

### DIFF
--- a/pygnssutils/gnssntripclient.py
+++ b/pygnssutils/gnssntripclient.py
@@ -289,18 +289,20 @@ class GNSSNTRIPClient:
         :rtype: str
         """
 
+
+        host = settings["server"] + ":" + str(settings["port"])
         mountpoint = settings["mountpoint"]
         version = settings["version"]
         user = settings["user"]
         password = settings["password"]
 
-        if mountpoint != "":
-            mountpoint = "/" + mountpoint  # sourcetable request
+        mountpoint = "/" + mountpoint  # sourcetable request
         user = user + ":" + password
         user = b64encode(user.encode(encoding="utf-8"))
         req = (
             f"GET {mountpoint} HTTP/1.1\r\n"
             + f"User-Agent: {USERAGENT}\r\n"
+            + f"Host: {host}\r\n"
             + f"Authorization: Basic {user.decode(encoding='utf-8')}\r\n"
             + f"Ntrip-Version: Ntrip/{version}\r\n"
         )


### PR DESCRIPTION
## Description

NTRIP V2 requires host to be sent, GET to have `/` for valid SOURCETABLEBLE request, some ntrip servers return 400 error code, but this is not responded to by this library.
This patch adds the `Host` line to the request, and always adds the `/` to the GET request, as blank entries are also invalid


## Testing

tested on "http://ntrip.data.gnss.ga.gov.au:2101/" -> retrieves sourcetable correctly
