### PR TITLE
Enhance ntrip client fixes #6

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "0.3.2"
+    "moduleversion": "0.3.3"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pygnssutils Release Notes
 
+### RELEASE 0.3.3-beta
+
+FIXES:
+
+1. Fix gnssntripclient issue #6 arising from blank lines in HTTP sourcetable responses.
+
 ### RELEASE 0.3.2-beta
 
 ENHANCEMENTS:

--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,7 @@
 <?xml version = "1.0"?>
 <project name="pygnssutils" default="build">
 	<property name="module.name" value="pygnssutils" />
-	<property name="version" value="0.3.2" />
+	<property name="version" value="0.3.3" />
 	<condition property="python" value="python">
 		<os family="windows" />
 	</condition>

--- a/pygnssutils/_version.py
+++ b/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/pygnssutils/gnssntripclient.py
+++ b/pygnssutils/gnssntripclient.py
@@ -526,8 +526,8 @@ class GNSSNTRIPClient:
                     ):
                         self._do_log(line, VERBOSITY_MEDIUM, False)
                         return line
-                    elif line == "":
-                        break
+                    # elif line == "":
+                    #     break
 
             except UnicodeDecodeError:
                 data = False

--- a/pygnssutils/helpstrings.py
+++ b/pygnssutils/helpstrings.py
@@ -120,6 +120,7 @@ GNSSNTRIPCLIENT_HELP = (
     + f"{GREEN}Keyword arguments (default):{NORMAL}\n\n"
     + "  server - (mandatory) NTRIP server URL ('')\n"
     + "  port - NTRIP port (2101)\n"
+    + "  mountpoint - NTRIP mountpoint (blank)\n"
     + "  version - NTRIP protocol version (2.0)\n"
     + "  user - NTRIP server login user (anon)\n"
     + "  password - NTRIP server login password (password)\n"


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

Fix `gnssntripclient` issue where blank lines in HTTP sourcetable response from NTRIP caster could prevent sourcetable being retrieved and processed.

Fixes #6

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- Tested against NTRIP casters specified in issue report

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
