### PR TITLE
Fix GGA won't be sent for the first time.

### DIFF
--- a/pygnssutils/gnssntripclient.py
+++ b/pygnssutils/gnssntripclient.py
@@ -125,7 +125,7 @@ class GNSSNTRIPClient:
         self._connected = False
         self._stopevent = Event()
         self._ntrip_thread = None
-        self._last_gga = datetime.now()
+        self._last_gga = datetime.fromordinal(1)
 
     def __enter__(self):
         """


### PR DESCRIPTION
## Description

Some casters use a fixed mountpoint (for example "AUTO") and won't send data until received GGA, this fixed _last_gga which caused GGA won't be sent for the first time.

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested with tests/testsuite.py
## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
