### PR TITLE
update HTTP GET Fixes #5

### DIFF
--- a/pygnssutils/gnssntripclient.py
+++ b/pygnssutils/gnssntripclient.py
@@ -54,7 +54,7 @@ from pygnssutils._version import __version__ as VERSION
 from pygnssutils.helpers import find_mp_distance
 
 TIMEOUT = 10
-USERAGENT = f"PYGNSSUTILS NTRIP Client/{VERSION}"
+USERAGENT = "NTRIP pygnssutils"
 NTRIP_HEADERS = {
     "Ntrip-Version": "Ntrip/2.0",
     "User-Agent": USERAGENT,
@@ -304,11 +304,13 @@ class GNSSNTRIPClient:
         user = user + ":" + password
         user = b64encode(user.encode(encoding="utf-8"))
         req = (
-            f"GET {mountpoint} HTTP/1.1\r\n"
+            f"GET {mountpoint} HTTP/1.0\r\n"
             + f"User-Agent: {USERAGENT}\r\n"
-            + f"Host: {host}\r\n"
+            + "Accept: */*\r\n"
+            # + f"Host: {host}\r\n"
             + f"Authorization: Basic {user.decode(encoding='utf-8')}\r\n"
-            + f"Ntrip-Version: Ntrip/{version}\r\n"
+            # + f"Ntrip-Version: Ntrip/{version}\r\n"
+            + "Connection: close\r\n"
         )
         req += "\r\n"  # NECESSARY!!!
         return req.encode(encoding="utf-8")


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

Amend HTTP GET string in `gnssntripclient` to fix previous HTTP 403 Forbidden error with certain casters (e.g. UNAVCO).

Fixes # 5

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested against rtgpsout.unavco.org, rtk2go.com and ntrip.data.gnss.ga.gov.au

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
