### PR TITLE
Add message period filter to GNSSStreamer class

### DIFF
--- a/pygnssutils/gnssdump.py
+++ b/pygnssutils/gnssdump.py
@@ -47,6 +47,7 @@ from pygnssutils.globals import (
     FORMAT_PARSEDSTRING,
     FORMAT_JSON,
     VERBOSITY_MEDIUM,
+    VERBOSITY_HIGH,
     LOGLIMIT,
     EPILOG,
 )
@@ -280,8 +281,17 @@ class GNSSStreamer:
         self._stopevent = True
         mss = "" if self._msgcount == 1 else "s"
         ers = "" if self._errcount == 1 else "s"
-        msg = f"Streaming terminated, {self._msgcount:,} message{mss} processed with {self._errcount:,} error{ers}.\n"
-        self._do_log(msg, VERBOSITY_MEDIUM)
+
+        msgs = []
+        msgs.append(
+            f"Streaming terminated, {self._msgcount:,} message{mss} "
+            f"processed with {self._errcount:,} error{ers}.\n"
+        )
+        msgs.append(f"{'Messages received': <22} {dict(self._msgtypecount)}")
+        msgs.append(f"{'Messages filtered:': <22} {dict(self._msgtypefilteredcount)}")
+        msgs.append(f"{'Messages sent:': <22} {dict(self._msgtypesentcount)}\n")
+        for msg in msgs:
+            self._do_log(msg, VERBOSITY_MEDIUM)
 
         if self._output is not None:
             self._output.close()
@@ -365,6 +375,10 @@ class GNSSStreamer:
                             toc = time.time()
                             time_since_last_msg = toc - tic
                             msgperiod = self._msgperiods[msgidentity]
+                            self._do_log(
+                                f"Time since last RTCM {msgidentity} message was sent: {time_since_last_msg}",
+                                VERBOSITY_HIGH,
+                            )
                             # multiplying by 0.95 so that if, for example,
                             # self._msgfilter = 1077(10) and an RTCM 1077
                             # message comes in 9.5-10 seconds after the previous

--- a/pygnssutils/gnssserver.py
+++ b/pygnssutils/gnssserver.py
@@ -52,7 +52,8 @@ class GNSSSocketServer:
         gnssserver inport=COM3 hostip=192.168.0.20 outport=50010 ntripmode=0
 
         :param object app: application from which this class is invoked (None)
-        :param str inport: (kwarg) serial port name (/dev/ttyACM1)
+        :param str inport: (kwarg) input serial port name (None)
+        :param str socket: (kwarg) input socket host:port
         :param int baudrate: (kwarg) serial baud rate (9600)
         :param int timeout: (kwarg) serial timeout in seconds (3)
         :param int hostip: (kwarg) host ip address (0.0.0.0)
@@ -79,7 +80,7 @@ class GNSSSocketServer:
             # 0.0.0.0 binds to all host IP addresses
             self._kwargs["hostip"] = kwargs.get("hostip", "0.0.0.0")
             # amend default as required
-            self._kwargs["port"] = kwargs.get("inport", "/dev/ttyACM1")
+            self._kwargs["port"] = kwargs.get("inport", None)
             self._kwargs["outport"] = int(
                 kwargs.get(
                     "outport", OUTPORT_NTRIP if self._kwargs["ntripmode"] else OUTPORT
@@ -299,7 +300,8 @@ def main():
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
     ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
-    ap.add_argument("-I", "--inport", required=True, help="Input serial port")
+    ap.add_argument("-I", "--inport", required=False, help="Input serial port")
+    ap.add_argument("-S", "--socket", required=False, help="Input socket host:port")
     ap.add_argument(
         "-O",
         "--outport",


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. Added message period filtering functionality to the `GNSSStreamer` class. This allows you to use a `msgfilter` like `"1006(60),1019(60),1077(10)"` to reduce the output rate of each message type. This is useful when rebroadcasting high-rate RTCM corrections over a low bitrate link (e.g. a satellite link).
2. Added total, filtered, and sent message counters for each message type
2. Modified `gnssserver.py` to allow input from a socket

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested against supplied unittest suite using vscode's Python unittest integration facilities
- [x] Tested new functionality by adding filtered message counters and passing a variety of strings to `--msgfilter`

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
