### PR TITLE
Rc 1.0.6

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,14 @@ Fixes # (issue)
 
 ## Testing
 
-Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
+Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
 
 - [ ] Test A
 - [ ] Test B
 
 ## Checklist:
 
+- [ ] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
 - [ ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
 - [ ] I have performed a self-review of my own code.
 - [ ] (*if appropriate*) I have cited my u-blox documentation source(s).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.5"
+    "moduleversion": "1.0.6"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -105,6 +105,7 @@
                 "build",
                 ".",
                 "--wheel",
+                "--sdist",
             ],
             "problemMatcher": []
         },
@@ -114,7 +115,13 @@
             "command": "${config:python.defaultInterpreterPath}",
             "args": [
                 "-m",
-                "pytest"
+                "pytest",
+                "--cov-report",
+                "html",
+                "--cov-fail-under",
+                "30",
+                "--cov=${config:distname}",
+                "tests/",
             ],
             "problemMatcher": []
         },

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pygnssutils Release Notes
 
+### RELEASE 1.0.6
+
+1. superfluous haversine helper, latlon2dms and latlon2dmm methods removed - use pynmeagps helpers instead
+1. Minimum pyubx2 version updated to 1.2.23
+1. Minimum pyspartn version updated to 0.1.4
+1. Minor updates to VSCode tasks and GitHub actions for pyproject.toml build framework
+
 ### RELEASE 1.0.5
 
 FIXES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,11 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "GNSS Command Line Utilities"
-version = "1.0.5"
+version = "1.0.6"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.7"
 classifiers = [
-    "License :: OSI Approved ::BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Environment :: MacOS X",
@@ -39,8 +38,8 @@ classifiers = [
     ]
 
 dependencies = [
-    "pyubx2>=1.2.22",
-    "pyspartn>=0.1.3",
+    "pyubx2>=1.2.23",
+    "pyspartn>=0.1.4",
     "pyserial>=3.5",
     "paho-mqtt>=1.6.1",
 ]
@@ -85,7 +84,7 @@ disable = """
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--cov --cov-report html --cov-report term-missing"
+addopts = "--cov --cov-report term-missing"
 pythonpath = ["src"]
 
 [tool.coverage.run]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyubx2>=1.2.22
-pyspartn>=0.1.3
+pyubx2>=1.2.23
+pyspartn>=0.1.4
 pyserial>=3.5
 paho-mqtt>=1.6.1

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/src/pygnssutils/helpers.py
+++ b/src/pygnssutils/helpers.py
@@ -11,54 +11,8 @@ Created on 26 May 2022
 
 from math import sin, cos, radians
 from pyubx2 import itow2utc
-from pynmeagps import haversine as hsine, latlon2dms as ll2dms, latlon2dmm as ll2dmm
 
-
-def haversine(
-    lat1: float, lon1: float, lat2: float, lon2: float, radius: float = 6378.137
-) -> float:
-    """
-    For backward compatibility - method now available from pynmeagps library.
-    Calculate spherical distance in km between two coordinates using haversine formula.
-
-    :param float lat1: lat1
-    :param float lon1: lon1
-    :param float lat2: lat2
-    :param float lon2: lon2
-    :param float radius: radius in km (Earth = 6378.137 km)
-    :return: spherical distance in km
-    :rtype: float
-    """
-
-    return hsine(lat1, lon1, lat2, lon2, radius)
-
-
-def latlon2dms(latlon: tuple) -> str:
-    """
-    For backward compatibility - method now available from pynmeagps library.
-    Convert decimal lat/lon to D.M.S format.
-
-    :param tuple latlon (lat, lon) as tuple
-    :return: lat lon in DMS format
-    :rtype: str
-    """
-
-    lat, lon = latlon
-    return ll2dms(lat, lon)
-
-
-def latlon2dmm(latlon: tuple) -> str:
-    """
-    For backward compatibility - method now available from pynmeagps library.
-    Convert decimal lat/lon to D.M.M format.
-
-    :param tuple latlon (lat, lon) as tuple
-    :return: lat lon in DMM format
-    :rtype: str
-    """
-
-    lat, lon = latlon
-    return ll2dmm(lat, lon)
+from pynmeagps import haversine
 
 
 def get_mp_distance(lat: float, lon: float, mp: list) -> float:


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

RELEASE 1.0.6

1. Superfluous haversine, latlon2dms and latlon2dmm helper methods removed - use pynmeagps helpers instead
1. Minimum pyubx2 version updated to 1.2.23
1. Minimum pyspartn version updated to 0.1.4
1. Minor updates to VSCode tasks and GitHub actions for pyproject.toml build framework

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] redundant helper tests removed

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
