### PR TITLE
Rc 1.0.8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.7"
+    "moduleversion": "1.0.8"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -78,6 +78,19 @@
             "problemMatcher": []
         },
         {
+            "label": "Sort Imports",
+            "type": "process",
+            "command": "${config:python.defaultInterpreterPath}",
+            "args": [
+                "-m",
+                "isort",
+                "src",
+                "--jobs",
+                "-1"
+            ],
+            "problemMatcher": []
+        },
+        {
             "label": "Format",
             "type": "process",
             "command": "${config:python.defaultInterpreterPath}",
@@ -210,6 +223,7 @@
                 "Install Test Dependencies",
                 "Install Dependencies",
                 "Security",
+                "Sort Imports",
                 "Format",
                 "Pylint",
                 "Test",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pygnssutils Release Notes
 
+### RELEASE CANDIDATE 1.0.8
+
+ENHANCEMENTS:
+
+1. Add `on_disconnect` callback to `gnssmqttclient.py` and enhance exception reporting back to calling app.
+1. Minor enhancements to SPARTN and NTRIP client exception handling.
+
 ### RELEASE 1.0.7
 
 CHANGES:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ENHANCEMENTS:
 
 1. Add IPv6 support in gnssntripclient.
+1. Add IPv6 support to gnssserver.
 1. Add `on_disconnect` callback to `gnssmqttclient.py` and enhance exception reporting back to calling app.
 1. Minor enhancements to SPARTN and NTRIP client exception handling.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 ENHANCEMENTS:
 
+1. Add IPv6 support in gnssntripclient.
 1. Add `on_disconnect` callback to `gnssmqttclient.py` and enhance exception reporting back to calling app.
 1. Minor enhancements to SPARTN and NTRIP client exception handling.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,7 @@
 
 ENHANCEMENTS:
 
-1. Add IPv6 support in gnssntripclient.
-1. Add IPv6 support to gnssserver.
+1. Add IPv6 support in gnssserver, gnssdump and gnssntripclient.
 1. Add `on_disconnect` callback to `gnssmqttclient.py` and enhance exception reporting back to calling app.
 1. Minor enhancements to SPARTN and NTRIP client exception handling.
 

--- a/examples/rtk_example.py
+++ b/examples/rtk_example.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     # NTRIP caster parameters - AMEND AS REQUIRED:
     # Ideally, mountpoint should be <30 km from location.
-    IPMODE = "IPv4"  # or "IPv6"
+    IPPROT = "IPv4"  # or "IPv6"
     NTRIP_SERVER = "ntrip_caster.com"
     NTRIP_PORT = 2101
     FLOWINFO = 0  # for IPv6
@@ -208,7 +208,7 @@ if __name__ == "__main__":
             print(f"Starting NTRIP client on {NTRIP_SERVER}:{NTRIP_PORT}...\n")
             with GNSSNTRIPClient(None, verbosity=VERBOSITY_LOW) as gnc:
                 streaming = gnc.run(
-                    inetmode=IPMODE,
+                    ipprot=IPPROT,
                     server=NTRIP_SERVER,
                     port=NTRIP_PORT,
                     flowinfo=FLOWINFO,

--- a/examples/rtk_example.py
+++ b/examples/rtk_example.py
@@ -153,8 +153,11 @@ if __name__ == "__main__":
 
     # NTRIP caster parameters - AMEND AS REQUIRED:
     # Ideally, mountpoint should be <30 km from location.
+    IPMODE = "IPv4"
     NTRIP_SERVER = "ntrip_caster.com"
     NTRIP_PORT = 2101
+    FLOWINFO = 0
+    SCOPEID = 0
     MOUNTPOINT = "MOUNTPOINT"
     NTRIP_USER = "myuser@mydomain.com"
     NTRIP_PASSWORD = "password"
@@ -205,8 +208,11 @@ if __name__ == "__main__":
             print(f"Starting NTRIP client on {NTRIP_SERVER}:{NTRIP_PORT}...\n")
             with GNSSNTRIPClient(None, verbosity=VERBOSITY_LOW) as gnc:
                 streaming = gnc.run(
+                    inetmode=IPMODE,
                     server=NTRIP_SERVER,
                     port=NTRIP_PORT,
+                    flowinfo=FLOWINFO,
+                    scopeid=SCOPEID,
                     mountpoint=MOUNTPOINT,
                     user=NTRIP_USER,
                     password=NTRIP_PASSWORD,

--- a/examples/rtk_example.py
+++ b/examples/rtk_example.py
@@ -153,11 +153,11 @@ if __name__ == "__main__":
 
     # NTRIP caster parameters - AMEND AS REQUIRED:
     # Ideally, mountpoint should be <30 km from location.
-    IPMODE = "IPv4"
+    IPMODE = "IPv4"  # or "IPv6"
     NTRIP_SERVER = "ntrip_caster.com"
     NTRIP_PORT = 2101
-    FLOWINFO = 0
-    SCOPEID = 0
+    FLOWINFO = 0  # for IPv6
+    SCOPEID = 0  # for IPv6
     MOUNTPOINT = "MOUNTPOINT"
     NTRIP_USER = "myuser@mydomain.com"
     NTRIP_PASSWORD = "password"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "paho-mqtt>=1.6.1",
     "pyserial>=3.5",
     "pyspartn>=0.1.6",
-    "pyubx2>=1.2.24",
+    "pyubx2>=1.2.25",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ deploy = [
 test = [
     "bandit",
     "black",
+    "isort",
     "pylint",
     "pytest",
     "pytest-cov",
@@ -77,8 +78,11 @@ test = [
 ]
 
 [tool.black]
-line-length = 88
 target-version = ['py37']
+
+[tool.isort]
+py_version = 37
+profile = "black"
 
 [tool.bandit]
 exclude_dirs = ["docs", "examples", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "GNSS Command Line Utilities"
-version = "1.0.7"
+version = "1.0.8"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -72,6 +72,7 @@ MINUBX_ID = [b"\x01\x07", b"\x01\x35"]
 TOPIC_RXM = "/pp/ubx/0236/ip"
 TOPIC_MGA = "/pp/ubx/mga"
 TOPIC_IP = "/pp/ip/{}"
+NTRIP_EVENT = "<<ntrip_read>>"
 SPARTN_EVENT = "<<spartn_read>>"
 SPARTN_PPSERVER = "pp.services.u-blox.com"
 OUTPORT_SPARTN = 8883

--- a/src/pygnssutils/gnssdump.py
+++ b/src/pygnssutils/gnssdump.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from datetime import datetime
 from io import BufferedWriter, TextIOWrapper
 from queue import Queue
-from socket import socket
+from socket import AF_INET, AF_INET6, SOCK_STREAM, socket
 from time import time
 
 import pynmeagps.exceptions as nme
@@ -118,14 +118,24 @@ class GNSSStreamer:
         self._port = kwargs.get("port", None)
         self._socket = kwargs.get("socket", None)
         self._outfile = kwargs.get("outfile", None)
+        self._inetmode = kwargs.get("inetmode", "IPv4")
         if self._socket is not None:
-            sock = self._socket.split(":")
-            if len(sock) != 2:
-                raise ParameterError(
-                    "socket keyword must be in the format host:port.\nType gnssdump -h for help."
-                )
-            self._socket_host = sock[0]
-            self._socket_port = int(sock[1])
+            if self._inetmode == "IPv6":  # IPv6 host ip must be enclosed in []
+                sock = self._socket.replace("[", "").split("]")
+                if len(sock) != 2:
+                    raise ParameterError(
+                        "IPv6 socket keyword must be in the format [host]:port"
+                    )
+                self._socket_host = sock[0]
+                self._socket_port = int(sock[1].replace(":", ""))
+            else:  # IPv4
+                sock = self._socket.split(":")
+                if len(sock) != 2:
+                    raise ParameterError(
+                        "IPv4 socket keyword must be in the format host:port"
+                    )
+                self._socket_host = sock[0]
+                self._socket_port = int(sock[1])
         self._filename = kwargs.get("filename", None)
         if (
             self._datastream is None
@@ -261,8 +271,14 @@ class GNSSStreamer:
             ) as self._stream:
                 self._start_reader()
         elif self._socket is not None:  # socket
-            with socket() as self._stream:
-                self._stream.connect((self._socket_host, self._socket_port))
+            family = AF_INET6 if self._inetmode == "IPv6" else AF_INET
+            server = (
+                (self._socket_host, self._socket_port, 0, 0)
+                if self._inetmode == "IPv6"
+                else (self._socket_host, self._socket_port)
+            )
+            with socket(family, SOCK_STREAM) as self._stream:
+                self._stream.connect(server)
                 self._start_reader()
         elif self._filename is not None:  # binary file
             with open(self._filename, "rb") as self._stream:
@@ -616,7 +632,19 @@ def main():
     arp.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
     arp.add_argument("-P", "--port", required=False, help="Serial port")
     arp.add_argument("-F", "--filename", required=False, help="Input file path/name")
-    arp.add_argument("-S", "--socket", required=False, help="Input socket host:port")
+    arp.add_argument(
+        "-S",
+        "--socket",
+        required=False,
+        help="Input socket host:port; enclose IPv6 host in []",
+    )
+    arp.add_argument(
+        "--inetmode",
+        required=False,
+        help="IP address family (for Socket connections)",
+        choices=["IPv4", "IPv6"],
+        default="IPv4",
+    )
     arp.add_argument(
         "--baudrate",
         required=False,

--- a/src/pygnssutils/gnssdump.py
+++ b/src/pygnssutils/gnssdump.py
@@ -89,7 +89,8 @@ class GNSSStreamer:
         :param object stream: (kwarg) stream object (must implement read(n) -> bytes method)
         :param str port: (kwarg) serial port name
         :param str filename: (kwarg) input file FQN
-        :param str socket: (kwarg) input socket host:port
+        :param str socket: (kwarg) input socket "host:port" - IPv6 addresses must be in format "[host]:port"
+        :param str ipprot: (kwarg) IP protocol IPv4 / IPv6
         :param int baudrate: (kwarg) serial baud rate (9600)
         :param int timeout: (kwarg) serial timeout in seconds (3)
         :param int validate: (kwarg) 1 = validate checksums, 0 = do not validate (1)
@@ -118,9 +119,9 @@ class GNSSStreamer:
         self._port = kwargs.get("port", None)
         self._socket = kwargs.get("socket", None)
         self._outfile = kwargs.get("outfile", None)
-        self._inetmode = kwargs.get("inetmode", "IPv4")
+        self._ipprot = kwargs.get("ipprot", "IPv4")
         if self._socket is not None:
-            if self._inetmode == "IPv6":  # IPv6 host ip must be enclosed in []
+            if self._ipprot == "IPv6":  # IPv6 host ip must be enclosed in []
                 sock = self._socket.replace("[", "").split("]")
                 if len(sock) != 2:
                     raise ParameterError(
@@ -271,10 +272,10 @@ class GNSSStreamer:
             ) as self._stream:
                 self._start_reader()
         elif self._socket is not None:  # socket
-            family = AF_INET6 if self._inetmode == "IPv6" else AF_INET
+            family = AF_INET6 if self._ipprot == "IPv6" else AF_INET
             server = (
                 (self._socket_host, self._socket_port, 0, 0)
-                if self._inetmode == "IPv6"
+                if self._ipprot == "IPv6"
                 else (self._socket_host, self._socket_port)
             )
             with socket(family, SOCK_STREAM) as self._stream:
@@ -639,9 +640,9 @@ def main():
         help="Input socket host:port; enclose IPv6 host in []",
     )
     arp.add_argument(
-        "--inetmode",
+        "--ipprot",
         required=False,
-        help="IP address family (for Socket connections)",
+        help="IP protocol (for Socket connections)",
         choices=["IPv4", "IPv6"],
         default="IPv4",
     )

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -7,8 +7,8 @@ from an IP (MQTT) source and (optionally) sending the data to a
 designated writeable output medium (serial, file, socket, queue).
 
 Calling app, if defined, can implement the following methods:
-- set_event()
-- dlg_spartnconfig.disconnect_ip()
+- set_event() - create <<spartn_read>> event
+- dialog() - return reference to MQTT client configuration dialog
 
 Thingstream > Location Services > PointPerfect Thing > Credentials
 Default location for key files is user's HOME directory
@@ -57,6 +57,7 @@ from pygnssutils.globals import (
 )
 
 TIMEOUT = 8
+DLGTSPARTN = "SPARTN Configuration"
 
 
 class GNSSMQTTClient:
@@ -377,9 +378,11 @@ class GNSSMQTTClient:
         if app is None:
             print(err)
         else:
-            if hasattr(app, "dlg_spartnconfig"):
-                if hasattr(app.dlg_spartnconfig, "disconnect_ip"):
-                    app.dlg_spartnconfig.disconnect_ip(f"{err} ")
+            if hasattr(app, "dialog"):
+                dlg = app.dialog(DLGTSPARTN)
+                if dlg is not None:
+                    if hasattr(dlg, "disconnect_ip"):
+                        dlg.disconnect_ip(f"{err} ")
 
     def _do_log(
         self,

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -6,9 +6,9 @@ which acts as an SPARTN MQTT client, retrieving correction data
 from an IP (MQTT) source and (optionally) sending the data to a
 designated writeable output medium (serial, file, socket, queue).
 
-Includes provision to be invoked from within PyGPSClient tkinter
-application (or any tkinter app which implements comparable
-GUI update methods).
+Calling app, if defined, can implement the following methods:
+- set_event()
+- dlg_spartnconfig.disconnect_ip()
 
 Thingstream > Location Services > PointPerfect Thing > Credentials
 Default location for key files is user's HOME directory
@@ -223,15 +223,15 @@ class GNSSMQTTClient:
         if settings["topic_key"]:
             topics.append((TOPIC_RXM, 0))
         userdata = {
-            "gnss": settings["output"],
+            "output": settings["output"],
             "topics": topics,
             "app": app,
-            "readevent": SPARTN_EVENT,
         }
 
         try:
             client = mqtt.Client(client_id=settings["clientid"], userdata=userdata)
             client.on_connect = self.on_connect
+            client.on_disconnect = self.on_disconnect
             client.on_message = self.on_message
             client.tls_set(certfile=settings["tlscrt"], keyfile=settings["tlskey"])
             i = 1
@@ -255,12 +255,8 @@ class GNSSMQTTClient:
                 # client.loop(timeout=0.1)
                 sleep(0.1)
         except (FileNotFoundError, TimeoutError) as err:
-            stopevent.set()
             self._do_log(f"ERROR! {err}", VERBOSITY_MEDIUM)
-            if app is not None:
-                if hasattr(app, "dlg_spartnconfig"):
-                    if hasattr(app.dlg_spartnconfig, "disconnect_ip"):
-                        app.dlg_spartnconfig.disconnect_ip(f"ERROR! {err}")
+            GNSSMQTTClient.on_error(userdata, err)
             self.stop()
             self.errevent.set()
 
@@ -281,7 +277,31 @@ class GNSSMQTTClient:
         if rcd == 0:
             client.subscribe(userdata["topics"])
         else:
-            print(f"PyPGSClient MQTT Client - Connection failed, rc: {rcd}!")
+            GNSSMQTTClient.on_error(userdata, rcd)
+
+    @staticmethod
+    def on_connect_fail(client, userdata, rcd):  # pylint: disable=unused-argument
+        """
+        The callback for when the client fails to connect to the server.
+
+        :param object client: client
+        :param list userdata:  list of user defined data items
+        :param int rcd: return status code
+        """
+
+        GNSSMQTTClient.on_error(userdata, rcd)
+
+    @staticmethod
+    def on_disconnect(client, userdata, rcd):  # pylint: disable=unused-argument
+        """
+        The callback for when the client disconnects from the server.
+
+        :param object client: client
+        :param list userdata:  list of user defined data items
+        :param int rcd: return status code
+        """
+
+        GNSSMQTTClient.on_error(userdata, rcd)
 
     @staticmethod
     def on_message(client, userdata, msg):  # pylint: disable=unused-argument
@@ -290,20 +310,24 @@ class GNSSMQTTClient:
         Some MQTT topics may contain more than one UBX or SPARTN message in
         a single payload.
 
+        :param object client: MQTT client
         :param list userdata: list of user defined data items
         :param object msg: SPARTN or UBX message topic content
         """
 
-        def do_write(output: object, raw: bytes, parsed: object):
+        def do_write(userdata: dict, raw: bytes, parsed: object):
             """
             Send SPARTN data to designated output medium.
 
             If output is Queue, will send both raw and parsed data.
 
-            :param object output: writeable output medium for SPARTN data
+            :param dict userdata: user defined data dict
             :param bytes raw: raw data
             :param object parsed: parsed message
             """
+
+            output = userdata["output"]
+            app = userdata["app"]
 
             if output is None:
                 print(parsed)
@@ -317,53 +341,45 @@ class GNSSMQTTClient:
                 elif isinstance(output, socket.socket):
                     output.sendall(raw)
 
-        def do_notify(app: object):
-            """
-            Notify any calling app of SPARTN read event.
-
-            :param object app: calling application
-            """
-
-            if hasattr(app, "appmaster"):
-                if hasattr(app.appmaster, "event_generate"):
-                    app.appmaster.event_generate("<<spartn_read>>")
+            if app is not None:
+                if hasattr(app, "set_event"):
+                    app.set_event(SPARTN_EVENT)
 
         if msg.topic in (TOPIC_MGA, TOPIC_RXM):  # multiple UBX MGA or RXM messages
             ubr = UBXReader(BytesIO(msg.payload), msgmode=SET)
             try:
                 for raw, parsed in ubr:
-                    # userdata["gnss"].put((raw, parsed))
-                    do_write(userdata["gnss"], raw, parsed)
-                    do_notify(userdata["app"])
+                    do_write(userdata, raw, parsed)
             except UBXParseError:
                 parsed = f"MQTT UBXParseError {msg.topic} {msg.payload}"
-                # userdata["gnss"].put((msg.payload, parsed))
-                do_write(userdata["gnss"], msg.payload, parsed)
-                do_notify(userdata["app"])
+                do_write(userdata, msg.payload, parsed)
         else:  # SPARTN protocol message
             spr = SPARTNReader(BytesIO(msg.payload))
             try:
                 for raw, parsed in spr:
-                    # userdata["gnss"].put((raw, parsed))
-                    do_write(userdata["gnss"], raw, parsed)
-                    do_notify(userdata["app"])
+                    do_write(userdata, raw, parsed)
             except (SPARTNMessageError, SPARTNParseError, SPARTNStreamError):
                 parsed = f"MQTT SPARTNParseError {msg.topic} {msg.payload}"
-                # userdata["gnss"].put((msg.payload, parsed))
-                do_write(userdata["gnss"], msg.payload, parsed)
-                do_notify(userdata["app"])
+                do_write(userdata, msg.payload, parsed)
 
-    def _app_update_status(self, status: bool, msg: tuple = None):
+    @staticmethod
+    def on_error(userdata: dict, err: object):
         """
-        THREADED
-        Update SPARTN connection status in calling application.
+        Report return code back to any calling application.
 
-        :param bool status: SPARTN server connection status
-        :param tuple msg: optional (message, color)
+        :param dict userdata: user defined data dict
+        :param object rcd: return code (int or str)
         """
 
-        if hasattr(self.__app, "update_spartn_status"):
-            self.__app.update_spartn_status(status, msg)
+        if isinstance(err, int):
+            err = mqtt.error_string(err)
+        app = userdata["app"]
+        if app is None:
+            print(err)
+        else:
+            if hasattr(app, "dlg_spartnconfig"):
+                if hasattr(app.dlg_spartnconfig, "disconnect_ip"):
+                    app.dlg_spartnconfig.disconnect_ip(f"{err} ")
 
     def _do_log(
         self,

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -81,7 +81,7 @@ class GNSSNTRIPClient:
         self._ntripqueue = Queue()
         # persist settings to allow any calling app to retrieve them
         self._settings = {
-            "inetmode": socket.AF_INET,
+            "ipprot": socket.AF_INET,
             "server": "",
             "port": 2101,
             "flowinfo": 0,
@@ -161,7 +161,7 @@ class GNSSNTRIPClient:
         User login credentials can be obtained from environment variables
         NTRIP_USER and NTRIP_PASSWORD, or passed as kwargs.
 
-        :param str inetmode: (kwarg) internet address mode IPv4/IPv6 ("IPv4")
+        :param str ipprot: (kwarg) IP protocol IPv4/IPv6 ("IPv4")
         :param str server: (kwarg) NTRIP server URL ("")
         :param int port: (kwarg) NTRIP port (2101)
         :param int flowinfo: (kwarg) flowinfo for IPv6 (0)
@@ -187,9 +187,9 @@ class GNSSNTRIPClient:
             password = os.getenv("NTRIP_PASSWORD", "password")
             self._last_gga = datetime.fromordinal(1)
 
-            inetmode = kwargs.get("inetmode", "IPv4")
-            self.settings["inetmode"] = (
-                socket.AF_INET6 if inetmode == "IPv6" else socket.AF_INET
+            ipprot = kwargs.get("ipprot", "IPv4")
+            self.settings["ipprot"] = (
+                socket.AF_INET6 if ipprot == "IPv6" else socket.AF_INET
             )
             self._settings["server"] = server = kwargs.get("server", "")
             self._settings["port"] = port = int(kwargs.get("port", OUTPORT_NTRIP))
@@ -435,13 +435,11 @@ class GNSSNTRIPClient:
             scopeid = int(settings["scopeid"])
             mountpoint = settings["mountpoint"]
             ggainterval = int(settings["ggainterval"])
-            if settings["inetmode"] == socket.AF_INET6:
+            if settings["ipprot"] == socket.AF_INET6:
                 conn = (server, port, flowinfo, scopeid)
             else:
                 conn = (server, port)
-            with socket.socket(
-                settings["inetmode"], socket.SOCK_STREAM
-            ) as self._socket:
+            with socket.socket(settings["ipprot"], socket.SOCK_STREAM) as self._socket:
                 self._socket.settimeout(TIMEOUT)
                 self._socket.connect(conn)
                 self._socket.sendall(self._formatGET(settings))
@@ -639,9 +637,9 @@ def main():
     ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
     ap.add_argument(
         "-I",
-        "--inetmode",
+        "--ipprot",
         required=False,
-        help="IP address family",
+        help="IP protocol",
         choices=["IPv4", "IPv6"],
         default="IPv4",
     )

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -194,7 +194,7 @@ class GNSSNTRIPClient:
             self._settings["server"] = server = kwargs.get("server", "")
             self._settings["port"] = port = int(kwargs.get("port", OUTPORT_NTRIP))
             self._settings["flowinfo"] = int(kwargs.get("flowinfo", 0))
-            self._settings["sourceid"] = int(kwargs.get("sourceid", 0))
+            self._settings["scopeid"] = int(kwargs.get("scopeid", 0))
             self._settings["mountpoint"] = mountpoint = kwargs.get("mountpoint", "")
             self._settings["version"] = kwargs.get("version", "2.0")
             self._settings["user"] = kwargs.get("user", user)

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -52,7 +52,7 @@ from pygnssutils.globals import (
     VERBOSITY_LOW,
     VERBOSITY_MEDIUM,
 )
-from pygnssutils.helpers import find_mp_distance
+from pygnssutils.helpers import find_mp_distance, format_conn, ipprot2int
 
 TIMEOUT = 10
 GGALIVE = 0
@@ -188,9 +188,7 @@ class GNSSNTRIPClient:
             self._last_gga = datetime.fromordinal(1)
 
             ipprot = kwargs.get("ipprot", "IPv4")
-            self.settings["ipprot"] = (
-                socket.AF_INET6 if ipprot == "IPv6" else socket.AF_INET
-            )
+            self.settings["ipprot"] = ipprot2int(ipprot)
             self._settings["server"] = server = kwargs.get("server", "")
             self._settings["port"] = port = int(kwargs.get("port", OUTPORT_NTRIP))
             self._settings["flowinfo"] = int(kwargs.get("flowinfo", 0))
@@ -435,10 +433,7 @@ class GNSSNTRIPClient:
             scopeid = int(settings["scopeid"])
             mountpoint = settings["mountpoint"]
             ggainterval = int(settings["ggainterval"])
-            if settings["ipprot"] == socket.AF_INET6:
-                conn = (server, port, flowinfo, scopeid)
-            else:
-                conn = (server, port)
+            conn = format_conn(settings["ipprot"], server, port, flowinfo, scopeid)
             with socket.socket(settings["ipprot"], socket.SOCK_STREAM) as self._socket:
                 self._socket.settimeout(TIMEOUT)
                 self._socket.connect(conn)

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -641,7 +641,7 @@ def main():
         "-I",
         "--inetmode",
         required=False,
-        help="Internet address mode",
+        help="IP address family",
         choices=["IPv4", "IPv6"],
         default="IPv4",
     )

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -58,7 +58,7 @@ class GNSSSocketServer:
         :param str socket: (kwarg) input socket host:port
         :param int baudrate: (kwarg) serial baud rate (9600)
         :param int timeout: (kwarg) serial timeout in seconds (3)
-        :param str inetmode: (kwarg) internet address mode IPv4/IPv6 ("IPv4")
+        :param str ipprot: (kwarg) IP protocol IPv4/IPv6 ("IPv4")
         :param int hostip: (kwarg) host ip address (0.0.0.0)
         :param str outport: (kwarg) TCP port (50010, or 2101 in NTRIP mode)
         :param int maxclients: (kwarg) maximum number of connected clients (5)
@@ -80,12 +80,12 @@ class GNSSSocketServer:
             # overrideable command line arguments..
             # 0 = TCP Socket Server mode, 1 = NTRIP Server mode
             self._kwargs["ntripmode"] = int(kwargs.get("ntripmode", 0))
-            inetmode = kwargs.get("inetmode", "IPv4")
-            self._kwargs["inetmode"] = AF_INET6 if inetmode == "IPv6" else AF_INET
+            ipprot = kwargs.get("ipprot", "IPv4")
+            self._kwargs["ipprot"] = AF_INET6 if ipprot == "IPv6" else AF_INET
             self._kwargs["flowinfo"] = int(kwargs.get("flowinfo", 0))
             self._kwargs["scopeid"] = int(kwargs.get("scopeid", 0))
             # 0.0.0.0 (or :: on IPv6) binds to all host IP addresses
-            host = "::" if inetmode == "IPv6" else "0.0.0.0"
+            host = "::" if ipprot == "IPv6" else "0.0.0.0"
             self._kwargs["hostip"] = kwargs.get("hostip", host)
             # amend default as required
             self._kwargs["port"] = kwargs.get("inport", None)
@@ -227,7 +227,7 @@ class GNSSSocketServer:
         Output (socket server) thread.
         """
 
-        if kwargs["inetmode"] == AF_INET6:
+        if kwargs["ipprot"] == AF_INET6:
             host = (kwargs["hostip"], kwargs["outport"], 0, 0)
         else:
             host = (kwargs["hostip"], kwargs["outport"])
@@ -239,7 +239,7 @@ class GNSSSocketServer:
                 kwargs["outputhandler"],
                 host,
                 ClientHandler,
-                inetmode=kwargs["inetmode"],
+                ipprot=kwargs["ipprot"],
             ) as self._socket_server:
                 self._socket_server.serve_forever()
         except OSError as err:
@@ -324,9 +324,9 @@ def main():
         default=50010,
     )
     arp.add_argument(
-        "--inetmode",
+        "--ipprot",
         required=False,
-        help="IP address family",
+        help="IP protocol",
         choices=["IPv4", "IPv6"],
         default="IPv4",
     )
@@ -468,7 +468,7 @@ def main():
 
     args = arp.parse_args()
     kwargs = vars(args)
-    if kwargs["hostip"] == "0.0.0.0" and kwargs["inetmode"] == "IPv6":
+    if kwargs["hostip"] == "0.0.0.0" and kwargs["ipprot"] == "IPv6":
         kwargs["hostip"] = "::"
 
     try:

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -76,7 +76,6 @@ class GNSSSocketServer:
         """
 
         try:
-            print(f"DEBUG gnssserver init kwargs {kwargs}")
             self._kwargs = kwargs
             # overrideable command line arguments..
             # 0 = TCP Socket Server mode, 1 = NTRIP Server mode

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -326,7 +326,7 @@ def main():
     arp.add_argument(
         "--inetmode",
         required=False,
-        help="Internet address mode",
+        help="IP address family",
         choices=["IPv4", "IPv6"],
         default="IPv4",
     )

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -76,6 +76,7 @@ class GNSSSocketServer:
         """
 
         try:
+            print(f"DEBUG gnssserver init kwargs {kwargs}")
             self._kwargs = kwargs
             # overrideable command line arguments..
             # 0 = TCP Socket Server mode, 1 = NTRIP Server mode
@@ -331,7 +332,11 @@ def main():
         default="IPv4",
     )
     arp.add_argument(
-        "-H", "--hostip", required=False, help="Host IP Address", default="0.0.0.0"
+        "-H",
+        "--hostip",
+        required=False,
+        help="Host IP Address Binding (0.0.0.0/:: = all)",
+        default="0.0.0.0",
     )
     arp.add_argument(
         "-N",
@@ -464,6 +469,8 @@ def main():
 
     args = arp.parse_args()
     kwargs = vars(args)
+    if kwargs["hostip"] == "0.0.0.0" and kwargs["inetmode"] == "IPv6":
+        kwargs["hostip"] = "::"
 
     try:
         with GNSSSocketServer(**kwargs) as server:

--- a/src/pygnssutils/helpers.py
+++ b/src/pygnssutils/helpers.py
@@ -10,6 +10,7 @@ Created on 26 May 2022
 # pylint: disable=invalid-name
 
 from math import cos, radians, sin
+from socket import AF_INET, AF_INET6
 
 from pynmeagps import haversine
 from pyubx2 import itow2utc
@@ -136,3 +137,57 @@ def format_json(message: object) -> str:
     stg += f"{end}{end}"
 
     return stg
+
+
+def format_conn(
+    family: int, server: str, port: int, flowinfo: int = 0, scopeid: int = 0
+) -> tuple:
+    """
+    Return formatted socket connection string.
+
+    :param int family: IP family (AF_INET, AF_INET6)
+    :param str server: server
+    :param int port: port
+    :param int flowinfo: flow info (0)
+    :param int scopeid: scope ID (0)
+    :return: connection tuple
+    :rtype: tuple
+    """
+
+    if family == AF_INET6:
+        return (server, port, flowinfo, scopeid)
+    if family == AF_INET:
+        return (server, port)
+    raise ValueError(f"Invalid family value {family}")
+
+
+def ipprot2int(family: str) -> int:
+    """
+    Convert IP family string to integer.
+
+    :param str family: family string ("IPv4", "IPv6")
+    :return: value as int AF_INET, AF_INET6
+    :rtype: int
+    """
+
+    if family == "IPv4":
+        return AF_INET
+    if family == "IPv6":
+        return AF_INET6
+    raise ValueError(f"Invalid family value {family}")
+
+
+def ipprot2str(family: int) -> str:
+    """
+    Convert IP family integer to string.
+
+    :param str family: family int (AF_INET, AF_INET6)
+    :return: value as str ("IPv4", "IPv6")
+    :rtype: int
+    """
+
+    if family == AF_INET:
+        return "IPv4"
+    if family == AF_INET6:
+        return "IPv6"
+    raise ValueError(f"Invalid family value {family}")

--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -31,12 +31,12 @@ from base64 import b64encode
 from datetime import datetime, timezone
 from os import getenv
 from queue import Queue
-from socket import AF_INET
 from socketserver import StreamRequestHandler, ThreadingTCPServer
 from threading import Event, Thread
 
 from pygnssutils._version import __version__ as VERSION
 from pygnssutils.globals import CONNECTED, DISCONNECTED
+from pygnssutils.helpers import ipprot2int
 
 # from pygpsclient import version as PYGPSVERSION
 
@@ -60,6 +60,7 @@ class SocketServer(ThreadingTCPServer):
         Overridden constructor.
 
         :param Frame app: reference to main application class (if any)
+        :param str ipprot: IP protocol family (IPv4, IPv6)
         :param int ntripmode: 0 = open socket server, 1 = NTRIP server
         :param int maxclients: max no of clients allowed
         :param Queue msgqueue: queue containing raw GNSS messages
@@ -79,7 +80,7 @@ class SocketServer(ThreadingTCPServer):
             self.clientqueues.append({"client": None, "queue": Queue()})
         self._start_read_thread()
         self.daemon_threads = True  # stops deadlock on abrupt termination
-        self.address_family = kwargs.pop("ipprot", AF_INET)
+        self.address_family = ipprot2int(kwargs.pop("ipprot", "IPv4"))
         super().__init__(*args, **kwargs)
 
     def server_close(self):

--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -79,7 +79,7 @@ class SocketServer(ThreadingTCPServer):
             self.clientqueues.append({"client": None, "queue": Queue()})
         self._start_read_thread()
         self.daemon_threads = True  # stops deadlock on abrupt termination
-        self.address_family = kwargs.pop("inetmode", AF_INET)
+        self.address_family = kwargs.pop("ipprot", AF_INET)
         super().__init__(*args, **kwargs)
 
     def server_close(self):

--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -31,6 +31,7 @@ from base64 import b64encode
 from datetime import datetime, timezone
 from os import getenv
 from queue import Queue
+from socket import AF_INET
 from socketserver import StreamRequestHandler, ThreadingTCPServer
 from threading import Event, Thread
 
@@ -78,7 +79,7 @@ class SocketServer(ThreadingTCPServer):
             self.clientqueues.append({"client": None, "queue": Queue()})
         self._start_read_thread()
         self.daemon_threads = True  # stops deadlock on abrupt termination
-
+        self.address_family = kwargs.pop("inetmode", AF_INET)
         super().__init__(*args, **kwargs)
 
     def server_close(self):

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -10,10 +10,18 @@ Created on 26 May 2022
 # pylint: disable=line-too-long, invalid-name, missing-docstring, no-member
 
 import unittest
-
+from socket import AF_INET, AF_INET6
 from pyubx2 import UBXReader, itow2utc
 
-from pygnssutils.helpers import cel2cart, find_mp_distance, format_json, get_mp_distance
+from pygnssutils.helpers import (
+    cel2cart,
+    find_mp_distance,
+    format_conn,
+    ipprot2int,
+    ipprot2str,
+    format_json,
+    get_mp_distance,
+)
 from tests.test_sourcetable import TESTSRT
 
 
@@ -119,6 +127,34 @@ class StaticTest(unittest.TestCase):
         lon = ""
         res = get_mp_distance(lat, lon, mp)
         self.assertEqual(res, None)
+
+    def testformatconn(self):  # test format connection string
+        res = format_conn(AF_INET, "192.168.0.23", 50010)
+        self.assertEqual(res, ("192.168.0.23", 50010))
+        res = format_conn(AF_INET6, "fe80::5f:89a3:300f:2dfa%en0", 50010)
+        self.assertEqual(res, ("fe80::5f:89a3:300f:2dfa%en0", 50010, 0, 0))
+        res = format_conn(AF_INET6, "fe80::5f:89a3:300f:2dfa%en0", 50010, 3456, 12)
+        self.assertEqual(res, ("fe80::5f:89a3:300f:2dfa%en0", 50010, 3456, 12))
+
+    def testformatconnerr(self):  # test format connection string
+        with self.assertRaisesRegex(ValueError, "Invalid family value 99"):
+            format_conn(99, "192.168.0.23", 50010)
+
+    def testipprot2int(self):  # test IP family to int
+        self.assertEqual(AF_INET, ipprot2int("IPv4"))
+        self.assertEqual(AF_INET6, ipprot2int("IPv6"))
+
+    def testipprot2interr(self):  # test IP family to int invalid
+        with self.assertRaisesRegex(ValueError, "Invalid family value IPv99"):
+            ipprot2int("IPv99")
+
+    def testipprot2str(self):  # test IP family to str
+        self.assertEqual("IPv4", ipprot2str(AF_INET))
+        self.assertEqual("IPv6", ipprot2str(AF_INET6))
+
+    def testipprot2strerr(self):  # test IP family to str invalid
+        with self.assertRaisesRegex(ValueError, "Invalid family value 99"):
+            ipprot2str(99)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

RELEASE CANDIDATE 1.0.8

ENHANCEMENTS:

1. Add IPv6 support in gnssserver, gnssdump and gnssntripclient via new keyword argument `--ipprot`.
1. Add `on_disconnect` callback to gnssmqttclient.py and enhance exception reporting back to calling app.
1. Minor enhancements to SPARTN and NTRIP client exception handling.


Fixes #27 
Fixes mqtt connection errors not reported back to client

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
