### PR TITLE
remove Python 3.7

### DIFF
--- a/.github/workflows/checkpr.yml
+++ b/.github/workflows/checkpr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.9"
+    "moduleversion": "1.0.10"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ If you're adding or amending UBX payload definitions or configuration database k
 ## Coding conventions
 
 * This is open source software. Code should be as simple and transparent as possible. Favour clarity over brevity.
-* The code should be compatible with Python >= 3.7.
+* The code should be compatible with Python >= 3.8.
 * The core code should be as generic and reusable as possible. We endeavour to limit the amount of processing dedicated to specific UBX message types, though this is sometimes unavoidable.
 * Avoid external library dependencies unless there's a compelling reason not to.
 * We use and recommend [Visual Studio Code](https://code.visualstudio.com/) with the [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) for development and testing.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Contributions welcome - please refer to [CONTRIBUTING.MD](https://github.com/sem
 [![PyPI version](https://img.shields.io/pypi/v/pygnssutils.svg?style=flat)](https://pypi.org/project/pygnssutils/)
 ![PyPI downloads](https://img.shields.io/pypi/dm/pygnssutils.svg?style=flat)
 
-`pygnssutils` is compatible with Python >=3.7. It is recommended that the Python 3 scripts (bin) folder is in your PATH.
+`pygnssutils` is compatible with Python >=3.8. It is recommended that the Python 3 scripts (bin) folder is in your PATH.
 
 In the following, `python3` & `pip` refer to the Python 3 executables. You may need to type 
 `python` or `pip3`, depending on your particular environment.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # pygnssutils Release Notes
 
-### RELEASE CANDIDATE 1.0.9
+### RELEASE CANDIDATE 1.0.10.
+
+1. Python 3.7 is officially end of life on 27 June 2023. This change removes Python 3.7 from workflows and documentation.
+1. No other functional changes.
+
+### RELEASE 1.0.9
 
 FIXES:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,10 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "GNSS Command Line Utilities"
-version = "1.0.9"
+version = "1.0.10"
 license = {file = "LICENSE"}
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
@@ -26,7 +26,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: End Users/Desktop",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -40,8 +39,8 @@ classifiers = [
 dependencies = [
     "paho-mqtt>=1.6.1",
     "pyserial>=3.5",
-    "pyspartn>=0.1.6",
-    "pyubx2>=1.2.26",
+    "pyspartn>=0.1.7",
+    "pyubx2>=1.2.27",
 ]
 
 [project.scripts]
@@ -78,10 +77,10 @@ test = [
 ]
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.isort]
-py_version = 37
+py_version = 38
 profile = "black"
 
 [tool.bandit]
@@ -92,7 +91,7 @@ skips = ["B104","B307"] # bind 0.0.0.0; use of eval
 jobs = 0
 reports = "y"
 recursive = "y"
-py-version = "3.7"
+py-version = "3.8"
 fail-under = "9.8"
 fail-on = "E,F"
 clear-cache-post-run = "y"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. Python 3.7 is officially end of life on 27 June 2023. This change removes Python 3.7 from workflows and documentation.
1. No other functional changes.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
