### PR TITLE
Add configuration setter to GNSSNTRIPClient & GNSSMQTTClient

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.12"
+    "moduleversion": "1.0.13"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pygnssutils Release Notes
 
+### RELEASE CANDIDATE 1.0.13
+
+CHANGES:
+
+1. Add settings.setter methods to GNSSNTRIPClient and GNSSMQTTClient (to support saving settings in `PyGPSClient>=1.4.1` json configuration file). No functional changes to command line clients.
+
 ### RELEASE 1.0.12
 
 CHANGES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.12"
+version = "1.0.13"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.12"
+__version__ = "1.0.13"

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -128,6 +128,16 @@ class GNSSMQTTClient:
 
         return self._settings
 
+    @settings.setter
+    def settings(self, settings: dict):
+        """
+        Setter for SPARTN IP settings.
+
+        :param dict settings: SPARTN IP settings dictionary
+        """
+
+        self._settings = settings
+
     @property
     def connected(self):
         """

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -143,6 +143,16 @@ class GNSSNTRIPClient:
 
         return self._settings
 
+    @settings.setter
+    def settings(self, settings: dict):
+        """
+        Setter for NTRIP settings.
+
+        :param dict settings: NTRIP settings dictionary
+        """
+
+        self._settings = settings
+
     @property
     def connected(self):
         """


### PR DESCRIPTION
# pygnssutils Pull Request Template

RELEASE CANDIDATE 1.0.13

CHANGES:

1. Add settings.setter methods to GNSSNTRIPClient and GNSSMQTTClient (to support saving settings in PyGPSClient>=1.4.1 json configuration file). No functional changes to command line clients.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
