### PR TITLE
RC 1.0.14

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.13"
+    "moduleversion": "1.0.14"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # pygnssutils Release Notes
 
-### RELEASE CANDIDATE 1.0.13
+### RELEASE CANDIDATE 1.0.14
+
+CHANGES:
+
+1. GNSSNTRIPClient amended to output sourcetable and closest mountpoint to designated output medium, if `--output` argument is not `None` and `--mountpoint` argument is blank. Previously only output RTCM3 data.
+
+### RELEASE 1.0.13
 
 CHANGES:
 

--- a/examples/rtk_example_auto.py
+++ b/examples/rtk_example_auto.py
@@ -22,20 +22,20 @@ CONNECTED = 1
 
 if __name__ == "__main__":
     # GNSS receiver serial port parameters - AMEND AS REQUIRED:
-    SERIAL_PORT = "/dev/tty.usbmodem1301"
+    SERIAL_PORT = "/dev/ttyACM1"
     BAUDRATE = 38400
     TIMEOUT = 10
 
     # NTRIP caster parameters - AMEND AS REQUIRED:
     # Ideally, mountpoint should be <30 km from location.
     IPPROT = "IPv4"  # or "IPv6"
-    NTRIP_SERVER = "rtk2go.com"
+    NTRIP_SERVER = "myntripcaster.com"
     NTRIP_PORT = 2101
     FLOWINFO = 0  # for IPv6
     SCOPEID = 0  # for IPv6
     MOUNTPOINT = ""  # leave blank to retrieve sourcetable
-    NTRIP_USER = "semuadmin@semuconsulting.com"
-    NTRIP_PASSWORD = "password"
+    NTRIP_USER = "myuser@mydomain.com"
+    NTRIP_PASSWORD = "mypassword"
 
     # NMEA GGA sentence status - AMEND AS REQUIRED:
     GGAMODE = 0  # use fixed reference position (0 = use live position)

--- a/examples/rtk_example_auto.py
+++ b/examples/rtk_example_auto.py
@@ -22,19 +22,19 @@ CONNECTED = 1
 
 if __name__ == "__main__":
     # GNSS receiver serial port parameters - AMEND AS REQUIRED:
-    SERIAL_PORT = "/dev/ttyACM1"
+    SERIAL_PORT = "/dev/tty.usbmodem1301"
     BAUDRATE = 38400
     TIMEOUT = 10
 
     # NTRIP caster parameters - AMEND AS REQUIRED:
     # Ideally, mountpoint should be <30 km from location.
     IPPROT = "IPv4"  # or "IPv6"
-    NTRIP_SERVER = "yourcaster.com"
+    NTRIP_SERVER = "rtk2go.com"
     NTRIP_PORT = 2101
     FLOWINFO = 0  # for IPv6
     SCOPEID = 0  # for IPv6
     MOUNTPOINT = ""  # leave blank to retrieve sourcetable
-    NTRIP_USER = "youruser@domain.com"
+    NTRIP_USER = "semuadmin@semuconsulting.com"
     NTRIP_PASSWORD = "password"
 
     # NMEA GGA sentence status - AMEND AS REQUIRED:

--- a/examples/rtk_example_auto.py
+++ b/examples/rtk_example_auto.py
@@ -1,0 +1,114 @@
+"""
+pygnssutils - rtk_example_auto.py
+
+Adaptation of rtk_example which 'auto-detects' the closest mountpoint.
+
+Created on 27 Aug 2023
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2022
+:license: BSD 3-Clause
+"""
+# pylint: disable=invalid-name
+
+from queue import Queue, Empty
+from threading import Event
+from time import sleep
+
+from pygnssutils import VERBOSITY_LOW, GNSSNTRIPClient
+from gnssapp import GNSSSkeletonApp
+
+CONNECTED = 1
+
+if __name__ == "__main__":
+    # GNSS receiver serial port parameters - AMEND AS REQUIRED:
+    SERIAL_PORT = "/dev/ttyACM1"
+    BAUDRATE = 38400
+    TIMEOUT = 10
+
+    # NTRIP caster parameters - AMEND AS REQUIRED:
+    # Ideally, mountpoint should be <30 km from location.
+    IPPROT = "IPv4"  # or "IPv6"
+    NTRIP_SERVER = "yourcaster.com"
+    NTRIP_PORT = 2101
+    FLOWINFO = 0  # for IPv6
+    SCOPEID = 0  # for IPv6
+    MOUNTPOINT = ""  # leave blank to retrieve sourcetable
+    NTRIP_USER = "youruser@domain.com"
+    NTRIP_PASSWORD = "password"
+
+    # NMEA GGA sentence status - AMEND AS REQUIRED:
+    GGAMODE = 0  # use fixed reference position (0 = use live position)
+    GGAINT = 60  # interval in seconds (-1 = do not send NMEA GGA sentences)
+    # Fixed reference coordinates (only used when GGAMODE = 1) - AMEND AS REQUIRED:
+    REFLAT = 51.176534
+    REFLON = -2.15453
+    REFALT = 40.8542
+    REFSEP = 26.1743
+
+    send_queue = Queue()
+    sourcetable_queue = Queue()
+    stop_event = Event()
+
+    try:
+        print(f"Starting GNSS reader/writer on {SERIAL_PORT} @ {BAUDRATE}...\n")
+        with GNSSSkeletonApp(
+            SERIAL_PORT,
+            BAUDRATE,
+            TIMEOUT,
+            stopevent=stop_event,
+            sendqueue=send_queue,
+            idonly=True,
+            enableubx=True,
+            showhacc=True,
+        ) as gna:
+            gna.run()
+            sleep(2)  # wait for receiver to output at least 1 navigation solution
+
+            mountpoint = ""
+            print(
+                f"Retrieving closest mountpoint from {NTRIP_SERVER}:{NTRIP_PORT}...\n"
+            )
+            with GNSSNTRIPClient(gna, verbosity=VERBOSITY_LOW) as gnc:
+                streaming = gnc.run(
+                    server=NTRIP_SERVER,
+                    port=NTRIP_PORT,
+                    mountpoint=mountpoint,
+                    ntripuser=NTRIP_USER,
+                    ntrippassword=NTRIP_PASSWORD,
+                    output=sourcetable_queue,
+                )
+
+                try:
+                    srt, (mountpoint, dist) = sourcetable_queue.get(timeout=3)
+                    if mountpoint is None:
+                        raise Empty
+                    print(
+                        f"\nClosest mountpoint is {mountpoint} which is {dist} km away\n"
+                    )
+                except Empty:
+                    stop_event.set()
+                    print("Unable to find closest mountpoint - quitting...\n")
+
+            print(
+                f"Streaming RTCM3 data from {NTRIP_SERVER}:{NTRIP_PORT}/{mountpoint}...\n"
+            )
+            with GNSSNTRIPClient(gna, verbosity=VERBOSITY_LOW) as gnc:
+                streaming = gnc.run(
+                    server=NTRIP_SERVER,
+                    port=NTRIP_PORT,
+                    mountpoint=mountpoint,
+                    ntripuser=NTRIP_USER,
+                    ntrippassword=NTRIP_PASSWORD,
+                    output=send_queue,
+                )
+
+                while (
+                    streaming and not stop_event.is_set()
+                ):  # run until user presses CTRL-C
+                    sleep(1)
+                sleep(1)
+
+    except KeyboardInterrupt:
+        stop_event.set()
+        print("Terminated by user")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.13"
+version = "1.0.14"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.13"
+__version__ = "1.0.14"

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -372,11 +372,14 @@ class GNSSNTRIPClient:
                     self._do_write(output, raw_data, parsed_data)
                 self._last_gga = datetime.now()
 
-    def _get_closest_mountpoint(self):
+    def _get_closest_mountpoint(self) -> tuple:
         """
         THREADED
         Find closest mountpoint in sourcetable
         if valid reference lat/lon are available.
+
+        :return: tuple of (mountpoint, distance)
+        :rtype: tuple
         """
 
         try:
@@ -392,7 +395,8 @@ class GNSSNTRIPClient:
             )
 
         except ValueError:
-            pass
+            return None, None
+        return closest_mp, dist
 
     def _start_read_thread(
         self,
@@ -457,7 +461,7 @@ class GNSSNTRIPClient:
                 if mountpoint != "":
                     self._send_GGA(ggainterval, output)
                 while not stopevent.is_set():
-                    rc = self._do_header(self._socket, stopevent)
+                    rc = self._do_header(self._socket, stopevent, output)
                     if rc == "0":  # streaming RTMC3 data from mountpoint
                         self._do_log(f"Using mountpoint {mountpoint}\n")
                         self._do_data(self._socket, stopevent, ggainterval, output)
@@ -481,7 +485,7 @@ class GNSSNTRIPClient:
             stopevent.set()
             self._connected = False
 
-    def _do_header(self, sock: socket, stopevent: Event) -> str:
+    def _do_header(self, sock: socket, stopevent: Event, output: object) -> str:
         """
         THREADED
         Parse response header lines.
@@ -511,7 +515,8 @@ class GNSSNTRIPClient:
                             stable.append(strbits)
                     elif line.find("ENDSOURCETABLE") >= 0:  # end of sourcetable
                         self._settings["sourcetable"] = stable
-                        self._get_closest_mountpoint()
+                        mp, dist = self._get_closest_mountpoint()
+                        self._do_write(output, stable, (mp, dist))
                         self._do_log("Complete sourcetable follows...\n")
                         for lines in self._settings["sourcetable"]:
                             self._do_log(lines, VERBOSITY_MEDIUM, False)
@@ -565,7 +570,7 @@ class GNSSNTRIPClient:
     def _do_write(self, output: object, raw: bytes, parsed: object):
         """
         THREADED
-        Send RTCM3 data to designated output medium.
+        Send sourcetable/closest mountpoint or RTCM3 data to designated output medium.
 
         If output is Queue, will send both raw and parsed data.
 
@@ -576,6 +581,9 @@ class GNSSNTRIPClient:
 
         self._do_log(parsed, VERBOSITY_MEDIUM)
         if output is not None:
+            # serialize sourcetable if outputting to stream
+            if isinstance(raw, list) and not isinstance(output, Queue):
+                raw = self._serialize_srt(raw)
             if isinstance(output, (Serial, BufferedWriter)):
                 output.write(raw)
             elif isinstance(output, TextIOWrapper):
@@ -589,6 +597,22 @@ class GNSSNTRIPClient:
         if self.__app is not None:
             if hasattr(self.__app, "set_event"):
                 self.__app.set_event(NTRIP_EVENT)
+
+    def _serialize_srt(self, sourcetable: list) -> str:
+        """
+        Serialize sourcetable.
+
+        :param list sourcetable: sourcetable as list
+        :return: sourcetable as string
+        :rtype: str
+        """
+
+        srt = ""
+        for row in sourcetable:
+            for i, col in enumerate(row):
+                dlm = "," if i < len(row) - 1 else "\r\n"
+                srt += f"{col}{dlm}"
+        return srt
 
     def _do_log(
         self,
@@ -747,6 +771,12 @@ def main():
         required=False,
         help="Fully qualified path to logfile folder",
         default=".",
+    )
+    ap.add_argument(
+        "--output",
+        required=False,
+        help="Output medium (defaults to stdout)",
+        default=None,
     )
 
     args = ap.parse_args()

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -598,13 +598,13 @@ class GNSSNTRIPClient:
             if hasattr(self.__app, "set_event"):
                 self.__app.set_event(NTRIP_EVENT)
 
-    def _serialize_srt(self, sourcetable: list) -> str:
+    def _serialize_srt(self, sourcetable: list) -> bytes:
         """
         Serialize sourcetable.
 
         :param list sourcetable: sourcetable as list
-        :return: sourcetable as string
-        :rtype: str
+        :return: sourcetable as bytes
+        :rtype: bytes
         """
 
         srt = ""
@@ -612,7 +612,7 @@ class GNSSNTRIPClient:
             for i, col in enumerate(row):
                 dlm = "," if i < len(row) - 1 else "\r\n"
                 srt += f"{col}{dlm}"
-        return srt
+        return bytearray(srt, "utf-8")
 
     def _do_log(
         self,


### PR DESCRIPTION
# pygnssutils Pull Request Template

RELEASE CANDIDATE 1.0.14

CHANGES:

1. GNSSNTRIPClient amended to output sourcetable and closest mountpoint values to designated output medium, if `--output` argument is not `None` and `--mountpoint` argument is blank. Previously only output RTCM3 data. Allows calling applications to retrieve sourcetable after GNSSNTRIPClient has terminated. Thanks to @SebKuzminsky for suggestion.

Fixes #40

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] tested via rtk_example_auto.py

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
