### PR TITLE
RELEASE CANDIDATE 1.0.22

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.21"
+    "moduleversion": "1.0.22"
 }

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Originally developed in support of the [PyGPSClient](https://github.com/semucons
 1. `GNSSStreamer` class and its associated [`gnssdump`](#gnssdump) CLI utility. This is essentially a configurable input/output wrapper around the [`pyubx2.UBXReader`](https://github.com/semuconsulting/pyubx2#reading) class with flexible message formatting and filtering options for NMEA, UBX and RTCM3 protocols.
 1. `GNSSSocketServer` class and its associated [`gnssserver`](#gnssserver) CLI utility. This implements a TCP Socket Server for GNSS data streams which is also capable of being run as a simple NTRIP Server.
 1. `GNSSNTRIPClient` class and its associated [`gnssntripclient`](#gnssntripclient) CLI utility. This implements
-a simple NTRIP Client which receives RTCM3 correction data from an NTRIP Server and (optionally) sends this to a
+a simple NTRIP Client which receives RTCM3 or SPARTN correction data from an NTRIP Server and (optionally) sends this to a
 designated output stream.
 1. `GNSSMQTTClient` class and its associated [`gnssmqttclient`](#gnssmqttclient) CLI utility. This implements
 a simple SPARTN IP (MQTT) Client which receives SPARTN correction data from an SPARTN IP location service sends this to a
@@ -242,7 +242,7 @@ Refer to the [Sphinx API documentation](https://www.semuconsulting.com/pygnssuti
 class pygnssutils.gnssntripclient.GNSSNTRIPClient(app=None, **kwargs)
 ```
 
-The `GNSSNTRIPClient` class provides a basic NTRIP Client capability and forms the basis of a [`gnssntripclient`](#gnssntripclient) CLI utility. It receives RTCM3 correction data from an NTRIP server and (optionally) sends this to a designated output stream. NTRIP server login credentials are set via command line arguments or environment variables `PYGPSCLIENT_USER` and `PYGPSCLIENT_PASSWORD`.
+The `GNSSNTRIPClient` class provides a basic NTRIP Client capability and forms the basis of a [`gnssntripclient`](#gnssntripclient) CLI utility. It receives RTCM3 or SPARTN correction data from an NTRIP server and (optionally) sends this to a designated output stream. NTRIP server login credentials are set via command line arguments or environment variables `PYGPSCLIENT_USER` and `PYGPSCLIENT_PASSWORD`.
 
 ### CLI Usage:
 
@@ -251,7 +251,7 @@ Assuming the Python 3 scripts (bin) directory is in your PATH, the CLI utility m
 To retrieve the sourcetable and determine the closest available mountpoint to the reference lat/lon, leave the mountpoint argument blank (the port defaults to 2101):
 
 ```shell
-> gnssntripclient --server rtk2go.com --ggamode 1 --reflat 37.23 --reflon 115.81 --ntripuser myuser --ntrippassword mypassword
+> gnssntripclient --server rtk2go.com --protocol RTCM --ggamode 1 --reflat 37.23 --reflon 115.81 --ntripuser myuser --ntrippassword mypassword
 2022-06-03 20:15:54.510294: Closest mountpoint to reference location 37.23,-115.81 = WW6RY, 351.51 km
 
 Complete sourcetable follows...

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # pygnssutils Release Notes
 
-### RELEASE CANDIDATE 1.0.21
+### RELEASE 1.0.22
+
+ENHANCEMENTS: 
+
+1. Add support for u-blox PointPerfect NTRIP SPARTN service in gnssntripclient.
+
+### RELEASE 1.0.21
 
 ENHANCEMENTS: 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.21"
+version = "1.0.22"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
@@ -37,7 +37,7 @@ dependencies = [
     "certifi>=2024.0.0",
     "paho-mqtt>=1.6.0",
     "pyserial>=3.5",
-    "pyspartn>=0.2.0",
+    "pyspartn>=0.2.1",
     "pyubx2>=1.2.39",
 ]
 

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.21"
+__version__ = "1.0.22"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -10,6 +10,7 @@ Created on 26 May 2022
 
 OUTPORT = 50010
 OUTPORT_NTRIP = 2101
+DEFAULT_TLS_PORTS = (443, 2102)
 MIN_NMEA_PAYLOAD = 3  # minimum viable length of NMEA message payload
 EARTH_RADIUS = 6371  # km
 DEFAULT_BUFSIZE = 4096  # buffer size for NTRIP client

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -97,7 +97,7 @@ class GNSSNTRIPClient:
             "mountpoint": "",
             "distance": "",
             "version": "2.0",
-            "protocol": RTCM,
+            "datatype": RTCM,
             "ntripuser": "anon",
             "ntrippassword": "password",
             "ggainterval": "None",
@@ -188,7 +188,7 @@ class GNSSNTRIPClient:
         :param int flowinfo: (kwarg) flowinfo for IPv6 (0)
         :param int scopeid: (kwarg) scopeid for IPv6 (0)
         :param str mountpoint: (kwarg) NTRIP mountpoint ("", leave blank to get sourcetable)
-        :param str protocol: (kwarg) Data protocol - RTCM or SPARTN ("RTCM")
+        :param str datatype: (kwarg) Data type - RTCM or SPARTN ("RTCM")
         :param str version: (kwarg) NTRIP protocol version ("2.0")
         :param str ntripuser: (kwarg) NTRIP authentication user ("anon")
         :param str ntrippassword: (kwarg) NTRIP authentication password ("password")
@@ -217,7 +217,7 @@ class GNSSNTRIPClient:
             self._settings["flowinfo"] = int(kwargs.get("flowinfo", 0))
             self._settings["scopeid"] = int(kwargs.get("scopeid", 0))
             self._settings["mountpoint"] = mountpoint = kwargs.get("mountpoint", "")
-            self._settings["protocol"] = kwargs.get("protocol", RTCM).upper()
+            self._settings["datatype"] = kwargs.get("datatype", RTCM).upper()
             self._settings["version"] = kwargs.get("version", "2.0")
             self._settings["ntripuser"] = kwargs.get(
                 "ntripuser", os.getenv("PYGPSCLIENT_USER", "user")
@@ -468,7 +468,7 @@ class GNSSNTRIPClient:
             scopeid = int(settings["scopeid"])
             mountpoint = settings["mountpoint"]
             ggainterval = int(settings["ggainterval"])
-            protocol = settings["protocol"]
+            datatype = settings["datatype"]
 
             conn = format_conn(settings["ipprot"], server, port, flowinfo, scopeid)
             with socket.socket(settings["ipprot"], socket.SOCK_STREAM) as self._socket:
@@ -489,7 +489,7 @@ class GNSSNTRIPClient:
                     if rc == "0":  # streaming RTMC3/SPARTN data from mountpoint
                         self._do_log(f"Using mountpoint {mountpoint}\n")
                         self._do_data(
-                            self._socket, protocol, stopevent, ggainterval, output
+                            self._socket, datatype, stopevent, ggainterval, output
                         )
                     elif rc == "1":  # retrieved sourcetable
                         stopevent.set()
@@ -570,7 +570,7 @@ class GNSSNTRIPClient:
     def _do_data(
         self,
         sock: socket,
-        protocol: str,
+        datatype: str,
         stopevent: Event,
         ggainterval: int,
         output: object,
@@ -580,7 +580,7 @@ class GNSSNTRIPClient:
         Read and parse incoming NTRIP RTCM3 data stream.
 
         :param socket sock: socket
-        :param str protocol: RTCM or SPARTN
+        :param str datatype: RTCM or SPARTN
         :param Event stopevent: stop event
         :param int ggainterval: GGA transmission interval seconds
         :param object output: output stream for RTCM3 messages
@@ -591,7 +591,7 @@ class GNSSNTRIPClient:
         parsed_data = None
 
         # parser will wrap socket as SocketStream
-        if protocol == SPARTN:
+        if datatype == SPARTN:
             parser = SPARTNReader(
                 sock,
                 quitonerror=ERR_IGNORE,
@@ -772,9 +772,9 @@ def main():
         default="2.0",
     )
     ap.add_argument(
-        "--protocol",
+        "--datatype",
         required=False,
-        help="Data protocol (RTCM or SPARTN)",
+        help="Data type (RTCM or SPARTN)",
         choices=[RTCM, "rtcm", SPARTN, "spartn"],
         default=RTCM,
     )

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -46,6 +46,7 @@ from pygnssutils._version import __version__ as VERSION
 from pygnssutils.exceptions import ParameterError
 from pygnssutils.globals import (
     DEFAULT_BUFSIZE,
+    DEFAULT_TLS_PORTS,
     EPILOG,
     HTTPERR,
     LOGLIMIT,
@@ -64,7 +65,6 @@ GGAFIXED = 1
 DLGTNTRIP = "NTRIP Configuration"
 RTCM = "RTCM"
 SPARTN = "SPARTN"
-DEFAULT_TLS_PORTS = (443, 2102)
 
 
 class GNSSNTRIPClient:

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -746,7 +746,7 @@ def main():
     ap.add_argument(
         "--https",
         required=False,
-        help="HTTPS (TLS) connection? 0 = HTTP, 1 = HTTPS (defaults to 1 if port = 443 or 2102)",
+        help=f"HTTPS (TLS) connection? 0 = HTTP, 1 = HTTPS (defaults to 1 if port in {DEFAULT_TLS_PORTS})",
         type=int,
         choices=[0, 1],
         default=0,


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. Add support for u-blox PointPerfect NTRIP SPARTN service in gnssntripclient.

Fixes https://github.com/semuconsulting/PyGPSClient/discussions/124

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested using new PointPerfect NTRIP SPARTN service

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
