### PR TITLE
RELEASE CANDIDATE 1.0.24

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.23"
+    "moduleversion": "1.0.24"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pygnssutils Release Notes
 
+### RELEASE 1.0.24
+
+FIXES:
+
+1. Further fixes to socket_server NTRIP caster to return properly formatted HTTP header with RTCM3 data stream.
+
 ### RELEASE 1.0.23
 
 FIXES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.23"
+version = "1.0.24"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.23"
+__version__ = "1.0.24"


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

FIXES:

1. Enhancements to socket_server NTRIP caster to improve compatibility with NTRIP clients like BNC and u-center. Now returns properly-formatted HTTP header with RTCM3 data stream.

Fixes issue with connection timeout on some NTRIP clients.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested using u-center 23.08 and BNC 2.13.0 NTRIP clients

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
