### PR TITLE
Waits correctly for the time specified in waittime

### DIFF
--- a/src/pygnssutils/ubxload.py
+++ b/src/pygnssutils/ubxload.py
@@ -66,7 +66,7 @@ class UBXLoader:
         self._serial_lock = Lock()
         self._out_queue = Queue()
         self._stop_event = Event()
-        self._last_ack = datetime.fromordinal(1)
+        self._last_ack = datetime.now()
 
         self._write_thread = Thread(
             target=self._write_data,


### PR DESCRIPTION
## Description

I couldn't use UBXLoader directly from my application, but it worked with 50% success on the command line.
In fact, I noticed that it was telling me that the command had failed when, in fact, it had gone through correctly but the ACKs had not been waited for sufficiently.

On investigating, I discovered that it didn't take the `waittime` into account at all. Replacing it with `datetime.now()` corrects the problem and I'm now able to use UBXLoader with 100% success directly via the `ubxload` command and from my application.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- No suited

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.