### PR TITLE
Enhance gnssntripclient & gnssmqttclient

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "python3.8InterpreterPath": "/Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8",
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.29"
+    "moduleversion": "1.0.30"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,12 @@
 
 ENHANCEMENTS:
 
-1. gnssntripclient: Add `--retry`, `--retryinterval` and `--timeout` parameters. NTRIP client can now automatically retry failed or inactive network connections. Type `gnssntripclient -h` for help.
-1. gnssntripclient: log levels amended, will output full parsed message if verbosity is HIGH, but only parsed identity if verbosity is MEDIUM
+1. Add automated network connection timeout and retry to gnssntripclient - new CLI arguments --retries, --retryinterval, --timeout. See gnssntripclient -h for help.
+1. Add multi-client TCP socket server output option to gnssntripclient and gnssmqttclient - new CLI argument --cliout 3.
+1. Refactor utilties to use standard Python logging module - --verbosity arguments are now mapped to logging levels (0 low => error, critical; 1 medium => warning; 2 high => info; 3 debug => debug). `--logtofile` CLI argument now contains fully qualified path to logfile, or "" to log to stderr; `--logpath` argument removed.
+1. Refactor utilities to use separate *_cli.py module for command line argument parsing.
+
+Use `-h` for help.
 
 ### RELEASE 1.0.29
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pygnssutils Release Notes
 
+### RELEASE 1.0.30
+
+ENHANCEMENTS:
+
+1. gnssntripclient: Add `--retry`, `--retryinterval` and `--timeout` parameters. NTRIP client can now automatically retry failed or inactive network connections. Type `gnssntripclient -h` for help.
+1. gnssntripclient: log levels amended, will output full parsed message if verbosity is HIGH, but only parsed identity if verbosity is MEDIUM
+
 ### RELEASE 1.0.29
 
 ENHANCEMENTS:

--- a/docs/pygnssutils.rst
+++ b/docs/pygnssutils.rst
@@ -20,10 +20,10 @@ pygnssutils.globals module
    :undoc-members:
    :show-inheritance:
 
-pygnssutils.gnssdump module
----------------------------
+pygnssutils.gnssdump\_cli module
+--------------------------------
 
-.. automodule:: pygnssutils.gnssdump
+.. automodule:: pygnssutils.gnssdump_cli
    :members:
    :undoc-members:
    :show-inheritance:
@@ -36,6 +36,14 @@ pygnssutils.gnssmqttclient module
    :undoc-members:
    :show-inheritance:
 
+pygnssutils.gnssmqttclient\_cli module
+--------------------------------------
+
+.. automodule:: pygnssutils.gnssmqttclient_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pygnssutils.gnssntripclient module
 ----------------------------------
 
@@ -44,10 +52,34 @@ pygnssutils.gnssntripclient module
    :undoc-members:
    :show-inheritance:
 
+pygnssutils.gnssntripclient\_cli module
+---------------------------------------
+
+.. automodule:: pygnssutils.gnssntripclient_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pygnssutils.gnssserver module
 -----------------------------
 
 .. automodule:: pygnssutils.gnssserver
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pygnssutils.gnssserver\_cli module
+----------------------------------
+
+.. automodule:: pygnssutils.gnssserver_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pygnssutils.gnssstreamer module
+-------------------------------
+
+.. automodule:: pygnssutils.gnssstreamer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -112,6 +144,14 @@ pygnssutils.ubxsimulator module
 -------------------------------
 
 .. automodule:: pygnssutils.ubxsimulator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pygnssutils.ubxsimulator\_cli module
+------------------------------------
+
+.. automodule:: pygnssutils.ubxsimulator_cli
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.29"
+version = "1.0.30"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
@@ -43,14 +43,14 @@ dependencies = [
 ]
 
 [project.scripts]
-gnssdump = "pygnssutils.gnssdump:main"
-gnssserver = "pygnssutils.gnssserver:main"
-gnssntripclient = "pygnssutils.gnssntripclient:main"
-gnssmqttclient = "pygnssutils.gnssmqttclient:main"
+gnssdump = "pygnssutils.gnssdump_cli:main"
+gnssserver = "pygnssutils.gnssserver_cli:main"
+gnssntripclient = "pygnssutils.gnssntripclient_cli:main"
+gnssmqttclient = "pygnssutils.gnssmqttclient_cli:main"
 ubxsetrate = "pygnssutils.ubxsetrate:main"
 ubxsave = "pygnssutils.ubxsave:main"
 ubxload = "pygnssutils.ubxload:main"
-ubxsimulator = "pygnssutils.ubxsimulator:main"
+ubxsimulator = "pygnssutils.ubxsimulator_cli:main"
 ubxcompare = "pygnssutils.ubxcompare:main"
 
 [project.urls]
@@ -92,19 +92,22 @@ fail-under = "9.7"
 fail-on = "E,F"
 clear-cache-post-run = "y"
 disable = """
-    raw-checker-failed,
     bad-inline-option,
-    locally-disabled,
-    file-ignored,
-    suppressed-message,
-    useless-suppression,
     deprecated-pragma,
+    file-ignored,
+    locally-disabled,
+    logging-fstring-interpolation,
+    raw-checker-failed,
+    suppressed-message,
+    too-few-public-methods,
+    too-many-instance-attributes,
     use-symbolic-message-instead,
+    useless-suppression
 """
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--cov --cov-report html --cov-fail-under 33"
+addopts = "--cov --cov-report html --cov-fail-under 30"
 pythonpath = ["src"]
 
 [tool.coverage.run]

--- a/src/pygnssutils/__init__.py
+++ b/src/pygnssutils/__init__.py
@@ -9,10 +9,10 @@ Created on 27 Sep 2020
 from pygnssutils._version import __version__
 from pygnssutils.exceptions import GNSSStreamError, ParameterError
 from pygnssutils.globals import *
-from pygnssutils.gnssdump import GNSSStreamer
 from pygnssutils.gnssmqttclient import GNSSMQTTClient
 from pygnssutils.gnssntripclient import GNSSNTRIPClient
 from pygnssutils.gnssserver import GNSSSocketServer
+from pygnssutils.gnssstreamer import GNSSStreamer
 from pygnssutils.helpers import *
 from pygnssutils.mqttmessage import *
 from pygnssutils.ubxload import UBXLoader

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.29"
+__version__ = "1.0.30"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -38,7 +38,8 @@ LOGGING_LEVELS = {
 }
 DISCONNECTED = 0
 CONNECTED = 1
-LOGLIMIT = 2**20  # max size of logfile in bytes
+LOGFORMAT = "{asctime}.{msecs:.0f} - {levelname} - {name} - {message}"
+LOGLIMIT = 10485760  # max size of logfile in bytes
 NOGGA = -1
 EPILOG = (
     "© 2022 SEMU Consulting BSD 3-Clause license"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -8,8 +8,6 @@ Created on 26 May 2022
 :license: BSD 3-Clause
 """
 
-import logging
-
 CLIAPP = "CLI"
 OUTPORT = 50010
 OUTPORT_NTRIP = 2101
@@ -33,14 +31,14 @@ VERBOSITY_MEDIUM = 1
 VERBOSITY_HIGH = 2
 VERBOSITY_DEBUG = 3
 LOGGING_LEVELS = {
-    VERBOSITY_LOW: logging.ERROR,
-    VERBOSITY_MEDIUM: logging.WARNING,
-    VERBOSITY_HIGH: logging.INFO,
-    VERBOSITY_DEBUG: logging.DEBUG,
+    VERBOSITY_LOW: "ERROR",
+    VERBOSITY_MEDIUM: "WARNING",
+    VERBOSITY_HIGH: "INFO",
+    VERBOSITY_DEBUG: "DEBUG",
 }
 DISCONNECTED = 0
 CONNECTED = 1
-LOGLIMIT = 1000  # max lines in logfile
+LOGLIMIT = 2**20  # max size of logfile in bytes
 NOGGA = -1
 EPILOG = (
     "© 2022 SEMU Consulting BSD 3-Clause license"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -8,6 +8,9 @@ Created on 26 May 2022
 :license: BSD 3-Clause
 """
 
+import logging
+
+CLIAPP = "CLI"
 OUTPORT = 50010
 OUTPORT_NTRIP = 2101
 DEFAULT_TLS_PORTS = (443, 2102)
@@ -21,15 +24,28 @@ FORMAT_HEX = 4
 FORMAT_HEXTABLE = 8
 FORMAT_PARSEDSTRING = 16
 FORMAT_JSON = 32
+OUTPUT_NONE = 0
+OUTPUT_FILE = 1
+OUTPUT_SERIAL = 2
+OUTPUT_SOCKET = 3
 VERBOSITY_LOW = 0
 VERBOSITY_MEDIUM = 1
 VERBOSITY_HIGH = 2
 VERBOSITY_DEBUG = 3
+LOGGING_LEVELS = {
+    VERBOSITY_LOW: logging.ERROR,
+    VERBOSITY_MEDIUM: logging.WARNING,
+    VERBOSITY_HIGH: logging.INFO,
+    VERBOSITY_DEBUG: logging.DEBUG,
+}
 DISCONNECTED = 0
 CONNECTED = 1
 LOGLIMIT = 1000  # max lines in logfile
 NOGGA = -1
-EPILOG = "© 2022 SEMU Consulting BSD 3-Clause license - https://github.com/semuconsulting/pygnssutils/"
+EPILOG = (
+    "© 2022 SEMU Consulting BSD 3-Clause license"
+    " - https://github.com/semuconsulting/pygnssutils/"
+)
 
 GNSSLIST = {
     0: "GPS",
@@ -51,14 +67,18 @@ FIXES = {
     "NO FIX": 0,
 }
 
-HTTPERR = [
-    "400 Bad Request",
-    "401 Unauthorized",
-    "403 Forbidden",
-    "404 Not Found",
-    "405 Method Not Allowed",
-    "406 Not Acceptable",
-]
+HTTPCODES = {
+    200: "OK",
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    406: "Not Acceptable",
+    408: "Request Timeout",
+}
+
+HTTPERR = [f"{i[0]} {i[1]}" for i in HTTPCODES.items() if 400 <= i[0] <= 499]
 
 # ranges for ubxsetrate CLI
 ALLNMEA = "allnmea"
@@ -94,13 +114,4 @@ REGION_MAPPING = {
     (33.10, 132.20): "jp",  # West
     (36.30, 128.20): "kr",
     (39.20, -096.60): "us",
-}
-
-HTTPCODES = {
-    200: "OK",
-    400: "Bad Request",
-    401: "Unauthorized",
-    403: "Forbidden",
-    404: "Not Found",
-    405: "Method Not Allowed",
 }

--- a/src/pygnssutils/gnssdump_cli.py
+++ b/src/pygnssutils/gnssdump_cli.py
@@ -1,0 +1,186 @@
+"""
+gnssdump_cli.py
+
+CLI wrapper for GNSSStreamer class.
+
+Created on 24 Jul 2024
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2022
+:license: BSD 3-Clause
+"""
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
+from pygnssutils._version import __version__ as VERSION
+from pygnssutils.globals import (
+    CLIAPP,
+    EPILOG,
+    VERBOSITY_DEBUG,
+    VERBOSITY_HIGH,
+    VERBOSITY_LOW,
+    VERBOSITY_MEDIUM,
+)
+from pygnssutils.gnssstreamer import GNSSStreamer
+
+
+def main():
+    """
+    CLI Entry point.
+
+    :param: as per GNSSStreamer constructor.
+    :raises: ParameterError if parameters are invalid
+    """
+    # pylint: disable=raise-missing-from
+
+    ap = ArgumentParser(
+        description="One of either -P port, -S socket or -F filename must be specified",
+        epilog=EPILOG,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    ap.add_argument("-P", "--port", required=False, help="Serial port")
+    ap.add_argument("-F", "--filename", required=False, help="Input file path/name")
+    ap.add_argument(
+        "-S",
+        "--socket",
+        required=False,
+        help="Input socket host:port; enclose IPv6 host in []",
+    )
+    ap.add_argument(
+        "--ipprot",
+        required=False,
+        help="IP protocol (for Socket connections)",
+        choices=["IPv4", "IPv6"],
+        default="IPv4",
+    )
+    ap.add_argument(
+        "--baudrate",
+        required=False,
+        help="Serial baud rate",
+        type=int,
+        choices=[4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800],
+        default=9600,
+    )
+    ap.add_argument(
+        "--timeout",
+        required=False,
+        help="Serial timeout in seconds",
+        type=float,
+        default=3.0,
+    )
+    ap.add_argument(
+        "--format",
+        required=False,
+        help=(
+            "Output format 1 = parsed, 2 = binary, 4 = hex, 8 = tabulated hex, "
+            "16 = parsed as string, 32 = JSON (can be OR'd)"
+        ),
+        type=int,
+        default=1,
+    )
+    ap.add_argument(
+        "--validate",
+        required=False,
+        help="1 = validate checksums, 0 = do not validate",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--msgmode",
+        required=False,
+        help="0 = GET, 1 = SET, 2 = POLL, 3 = SETPOLL",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=0,
+    )
+    ap.add_argument(
+        "--parsebitfield",
+        required=False,
+        help="1 = parse UBX 'X' attributes as bitfields, 0 = leave as bytes",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--quitonerror",
+        required=False,
+        help="0 = ignore errors,  1 = log errors and continue, 2 = (re)raise errors",
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+    )
+    ap.add_argument(
+        "--protfilter",
+        required=False,
+        help="1 = NMEA, 2 = UBX, 4 = RTCM3 (can be OR'd)",
+        type=int,
+        choices=[1, 2, 3, 4, 5, 6, 7],
+        default=7,
+    )
+    ap.add_argument(
+        "--msgfilter",
+        required=False,
+        help=(
+            "Comma-separated string of message identities e.g. 'NAV-PVT,GNGSA,1087'. "
+            + "A period clause may be added to each msg identity e.g. 1087(10), "
+            + "signifying the minimum period in seconds between messages of this type."
+        ),
+        default=None,
+    )
+    ap.add_argument(
+        "--limit",
+        required=False,
+        help="Maximum number of messages to read (0 = unlimited)",
+        type=int,
+        default=0,
+    )
+    ap.add_argument(
+        "--verbosity",
+        required=False,
+        help=(
+            f"Log message verbosity {VERBOSITY_LOW} = low (error, critical), "
+            f"{VERBOSITY_MEDIUM} = medium (warning), "
+            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+        ),
+        type=int,
+        choices=[VERBOSITY_LOW, VERBOSITY_MEDIUM, VERBOSITY_HIGH, VERBOSITY_DEBUG],
+        default=VERBOSITY_HIGH,
+    )
+    ap.add_argument(
+        "--outfile",
+        required=False,
+        help="Fully qualified path to output file",
+        default=None,
+    )
+    ap.add_argument(
+        "--logtofile",
+        required=False,
+        help="fully qualified log file name, or '' for no log file",
+        type=str,
+        default="",
+    )
+    ap.add_argument(
+        "--outputhandler",
+        required=False,
+        help="Either writeable output medium or evaluable expression",
+    )
+    ap.add_argument(
+        "--errorhandler",
+        required=False,
+        help="Either writeable output medium or evaluable expression",
+    )
+
+    kwargs = vars(ap.parse_args())
+
+    try:
+        with GNSSStreamer(CLIAPP, **kwargs) as gns:
+            gns.run()
+
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -79,7 +79,9 @@ class GNSSMQTTClient:
 
         self.__app = app  # Reference to calling application class (if applicable)
         set_logging(
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM), kwargs.pop("logtofile", "")
+            logger,
+            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
+            kwargs.pop("logtofile", ""),
         )
         self._validargs = True
         clientid = getenv("MQTTCLIENTID", default="enter-client-id")

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -60,6 +60,8 @@ from pygnssutils.mqttmessage import MQTTMessage
 TIMEOUT = 8
 DLGTSPARTN = "SPARTN Configuration"
 
+logger = logging.getLogger(__name__)
+
 
 class GNSSMQTTClient:
     """
@@ -185,13 +187,13 @@ class GNSSMQTTClient:
             self._logpath = kwargs.get("logpath", self._logpath)
 
         except (ParameterError, ValueError, TypeError) as err:
-            logging.critical(
+            logger.critical(
                 f"Invalid input arguments {kwargs}\n{err}\nType gnssntripclient -h for help."
             )
             self._validargs = False
             return 0
 
-        logging.info(f"Starting MQTT client with arguments {self._settings}.")
+        logger.info(f"Starting MQTT client with arguments {self._settings}.")
         self._stopevent.clear()
         self._mqtt_thread = Thread(
             target=self._run,
@@ -213,7 +215,7 @@ class GNSSMQTTClient:
 
         self._stopevent.set()
         self._mqtt_thread = None
-        logging.info("MQTT Client Stopped.")
+        logger.info("MQTT Client Stopped.")
 
     def _run(
         self,
@@ -282,7 +284,7 @@ class GNSSMQTTClient:
                             f"Unable to connect to {settings['server']}"
                             + f":{settings['port']} in {timeout} seconds. {err}"
                         ) from err
-                    logging.info(f"Trying to connect {i} ...")
+                    logger.info(f"Trying to connect {i} ...")
                     sleep(timeout / 4)
                     i += 1
 
@@ -292,7 +294,7 @@ class GNSSMQTTClient:
                 # client.loop(timeout=0.1)
                 sleep(0.1)
         except (FileNotFoundError, TimeoutError) as err:
-            logging.critical(f"ERROR! {err}")
+            logger.critical(f"ERROR! {err}")
             GNSSMQTTClient.on_error(userdata, err)
             self.stop()
             self.errevent.set()
@@ -367,8 +369,8 @@ class GNSSMQTTClient:
             """
 
             if hasattr(parsed, "identity"):
-                logging.info(parsed.identity)
-            logging.debug(parsed)
+                logger.info(parsed.identity)
+            logger.debug(parsed)
 
             if output is not None:
                 if isinstance(output, (Serial, BufferedWriter)):
@@ -422,7 +424,7 @@ class GNSSMQTTClient:
             err = mqtt.error_string(err)
         app = userdata["app"]
         if app is None:
-            logging.error(err)
+            logger.error(err)
         else:
             if hasattr(app, "dialog"):
                 dlg = app.dialog(DLGTSPARTN)

--- a/src/pygnssutils/gnssmqttclient_cli.py
+++ b/src/pygnssutils/gnssmqttclient_cli.py
@@ -1,0 +1,270 @@
+"""
+gnssmqttclient_cli.py
+
+CLI wrapper for GNSSMQTTClient class.
+
+Created on 24 Jul 2024
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2023
+:license: BSD 3-Clause
+"""
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from datetime import datetime, timezone
+from os import getenv, path
+from pathlib import Path
+from queue import Queue
+from threading import Event, Thread
+from time import sleep
+
+from serial import Serial
+
+from pygnssutils._version import __version__ as VERSION
+from pygnssutils.globals import (
+    CLIAPP,
+    EPILOG,
+    OUTPORT_SPARTN,
+    OUTPUT_FILE,
+    OUTPUT_NONE,
+    OUTPUT_SERIAL,
+    OUTPUT_SOCKET,
+    SPARTN_PPSERVER,
+    VERBOSITY_DEBUG,
+    VERBOSITY_HIGH,
+    VERBOSITY_LOW,
+    VERBOSITY_MEDIUM,
+)
+from pygnssutils.gnssmqttclient import TIMEOUT, GNSSMQTTClient
+from pygnssutils.socket_server import runserver
+
+TIMEOUT = 8
+DLGTSPARTN = "SPARTN Configuration"
+
+
+def runclient(**kwargs):
+    """
+    Start MQTT client with CLI parameters.
+    """
+
+    with GNSSMQTTClient(CLIAPP, **kwargs) as gsc:
+        streaming = gsc.start(**kwargs)
+        while (
+            streaming and not kwargs["errevent"].is_set()
+        ):  # run until error or user presses CTRL-C
+            sleep(kwargs["waittime"])
+        sleep(kwargs["waittime"])
+
+
+def main():
+    """
+    CLI Entry point.
+
+    :param int waittime: response wait time in seconds (3)
+    :param: as per GNSSSPARTNClient constructor and run() method.
+    :raises: ParameterError if parameters are invalid
+    """
+    # pylint: disable=raise-missing-from
+
+    clientid = getenv("MQTTCLIENTID", default="enter-client-id")
+    ap = ArgumentParser(
+        description="Client ID can be read from environment variable MQTTCLIENTID",
+        epilog=EPILOG,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    ap.add_argument(
+        "-C",
+        "--clientid",
+        required=False,
+        help="Client ID",
+        default=clientid,
+    )
+    ap.add_argument(
+        "-S",
+        "--server",
+        required=False,
+        help="SPARTN MQTT server URL",
+        default=SPARTN_PPSERVER,
+    )
+    ap.add_argument(
+        "-P",
+        "--port",
+        required=False,
+        help="SPARTN MQTT server port",
+        type=int,
+        default=OUTPORT_SPARTN,
+    )
+    ap.add_argument(
+        "-R",
+        "--region",
+        required=False,
+        help="SPARTN region code",
+        choices=["us", "eu", "au", "kr", "jp"],
+        default="eu",
+    )
+    ap.add_argument(
+        "-M",
+        "--mode",
+        required=False,
+        help="SPARTN mode (0 - IP,1 - L-Band)",
+        type=int,
+        choices=[0, 1],
+        default=0,
+    )
+    ap.add_argument(
+        "--topic_ip",
+        required=False,
+        help="Subscribe to SPARTN IP topic for the selected region",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--topic_mga",
+        required=False,
+        help="Subscribe to UBX Assist-Now (MGA-EPH) topic",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--topic_key",
+        required=False,
+        help="Subscribe to UBX Key (RXM-SPARTNKEY) topic",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--tlscrt",
+        required=False,
+        help="Fully-qualified path to TLS cert (*.crt)",
+        default=path.join(Path.home(), f"device-{clientid}-pp-cert.crt"),
+    )
+    ap.add_argument(
+        "--tlskey",
+        required=False,
+        help="Fully-qualified path to TLS key (*.pem)",
+        default=path.join(Path.home(), f"device-{clientid}-pp-key.pem"),
+    )
+    ap.add_argument(
+        "--spartndecode",
+        required=False,
+        help="Decode payload?",
+        type=int,
+        choices=[0, 1],
+        default=0,
+    )
+    ap.add_argument(
+        "--spartnkey",
+        required=False,
+        help="Decryption key for encrypted payloads",
+        default=getenv("MQTTKEY", default=None),
+    )
+    ap.add_argument(
+        "--spartnbasedate",
+        required=False,
+        help="Decryption basedate for encrypted payloads",
+        default=datetime.now(timezone.utc),
+    )
+    ap.add_argument(
+        "--verbosity",
+        required=False,
+        help=(
+            f"Log message verbosity {VERBOSITY_LOW} = low (error, critical), "
+            f"{VERBOSITY_MEDIUM} = medium (warning), "
+            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+        ),
+        type=int,
+        choices=[VERBOSITY_LOW, VERBOSITY_MEDIUM, VERBOSITY_HIGH, VERBOSITY_DEBUG],
+        default=VERBOSITY_MEDIUM,
+    )
+    ap.add_argument(
+        "--logtofile",
+        required=False,
+        help="fully qualified log file name, or '' for no log file",
+        type=str,
+        default="",
+    )
+    ap.add_argument(
+        "--waittime",
+        required=False,
+        help="waitimer",
+        type=float,
+        default=0.5,
+    )
+    ap.add_argument(
+        "--timeout",
+        required=False,
+        help="MQTT connection timeout (seconds)",
+        type=int,
+        default=TIMEOUT,
+    )
+    ap.add_argument(
+        "--errevent",
+        required=False,
+        help="Error event",
+        default=Event(),
+    )
+    ap.add_argument(
+        "--clioutput",
+        required=False,
+        help=(
+            f"CLI output type {OUTPUT_NONE} = none, "
+            f"{OUTPUT_FILE} = binary file, "
+            f"{OUTPUT_SERIAL} = serial port, "
+            f"{OUTPUT_SOCKET} = TCP socket server"
+        ),
+        type=int,
+        choices=[OUTPUT_NONE, OUTPUT_FILE, OUTPUT_SERIAL, OUTPUT_SOCKET],
+        default=OUTPUT_NONE,
+    )
+    ap.add_argument(
+        "--output",
+        required=False,
+        help=(
+            "Output medium as formatted string. "
+            f"If clioutput = {OUTPUT_FILE}, format = file name (e.g. '/home/myuser/spartn.log'); "
+            f"If clioutput = {OUTPUT_SERIAL}, format = port@baudrate (e.g. '/dev/tty.ACM0@38400'); "
+            f"If clioutput = {OUTPUT_SOCKET}, format = hostip:port (e.g. '0.0.0.0:50010'). "
+            "NB: gnssmqttclient will have exclusive use of any serial or server port."
+        ),
+        default=None,
+    )
+
+    args = ap.parse_args()
+    kwargs = vars(args)
+
+    cliout = kwargs.pop("clioutput", OUTPUT_NONE)
+    try:
+        if cliout == OUTPUT_FILE:
+            filename = kwargs["output"]
+            with open(filename, "wb") as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SERIAL:
+            port, baud = kwargs["output"].split("@")
+            with Serial(port, int(baud), timeout=3) as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SOCKET:
+            host, port = kwargs["output"].split(":")
+            kwargs["output"] = Queue()
+            # socket server runs as background thread, piping
+            # output from mqtt client via a message queue
+            Thread(
+                target=runserver,
+                args=(host, int(port), kwargs["output"]),
+                daemon=True,
+            ).start()
+            runclient(**kwargs)
+        else:
+            kwargs["output"] = None
+            runclient(**kwargs)
+    except (KeyboardInterrupt, TimeoutError):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pygnssutils/gnssmqttclient_cli.py
+++ b/src/pygnssutils/gnssmqttclient_cli.py
@@ -36,7 +36,6 @@ from pygnssutils.globals import (
     VERBOSITY_MEDIUM,
 )
 from pygnssutils.gnssmqttclient import TIMEOUT, GNSSMQTTClient
-from pygnssutils.helpers import set_logging
 from pygnssutils.socket_server import runserver
 
 TIMEOUT = 8

--- a/src/pygnssutils/gnssmqttclient_cli.py
+++ b/src/pygnssutils/gnssmqttclient_cli.py
@@ -36,6 +36,7 @@ from pygnssutils.globals import (
     VERBOSITY_MEDIUM,
 )
 from pygnssutils.gnssmqttclient import TIMEOUT, GNSSMQTTClient
+from pygnssutils.helpers import set_logging
 from pygnssutils.socket_server import runserver
 
 TIMEOUT = 8

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -1,11 +1,10 @@
 """
 gnssntripclient.py
 
-Command line utility, installed with PyPi library pygnssutils,
-which acts as an NTRIP client, retrieving sourcetable and RTCM3
-correction data from an NTRIP server and (optionally)
-sending the correction data to a designated writeable output
-medium (serial, file, socket, queue).
+NTRIP client class, retrieving sourcetable and RTCM3 or SPARTN
+correction data from an NTRIP server and (optionally) sending
+the correction data to a designated writeable output medium
+(serial, file, socket, queue).
 
 Can also transmit client position back to NTRIP server at specified
 intervals via formatted NMEA GGA sentences.
@@ -24,13 +23,13 @@ Created on 03 Jun 2022
 
 # pylint: disable=invalid-name
 
+import logging
 import socket
 import ssl
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from base64 import b64encode
 from datetime import datetime, timedelta, timezone
 from io import BufferedWriter, TextIOWrapper
-from os import getenv, path
+from os import getenv
 from queue import Queue
 from threading import Event, Thread
 from time import sleep
@@ -42,22 +41,19 @@ from pyspartn import SPARTNMessageError, SPARTNParseError, SPARTNReader, SPARTNT
 from pyubx2 import ERR_IGNORE, RTCM3_PROTOCOL, UBXReader
 from serial import Serial
 
-from pygnssutils._version import __version__ as VERSION
 from pygnssutils.exceptions import ParameterError
 from pygnssutils.globals import (
+    CLIAPP,
     DEFAULT_BUFSIZE,
     DEFAULT_TLS_PORTS,
-    EPILOG,
     HTTPERR,
-    LOGLIMIT,
     MAXPORT,
     NOGGA,
     NTRIP_EVENT,
     OUTPORT_NTRIP,
-    VERBOSITY_LOW,
     VERBOSITY_MEDIUM,
 )
-from pygnssutils.helpers import find_mp_distance, format_conn, ipprot2int
+from pygnssutils.helpers import find_mp_distance, format_conn, ipprot2int, set_logging
 
 TIMEOUT = 10
 GGALIVE = 0
@@ -65,10 +61,10 @@ GGAFIXED = 1
 DLGTNTRIP = "NTRIP Configuration"
 RTCM = "RTCM"
 SPARTN = "SPARTN"
-OUTPUT_NONE = 0
-OUTPUT_FILE = 1
-OUTPUT_SERIAL = 2
-OUTPUT_SOCKET = 3
+MAX_RETRY = 5
+RETRY_INTERVAL = 10
+INACTIVITY_TIMEOUT = 10
+WAITTIME = 3
 
 
 class GNSSNTRIPClient:
@@ -81,17 +77,20 @@ class GNSSNTRIPClient:
         Constructor.
 
         :param object app: application from which this class is invoked (None)
-        :param object verbosity: (kwarg) log verbosity (1 = medium)
-        :param object logtofile: (kwarg) log to file (0 = False)
-        :param object logpath: (kwarg) log file path (".")
-        :param object clioutput: (kwarg) 0 = none, 1 = binary file, 2 = serial port
+        :param int verbosity: (kwarg) log verbosity (1 = medium)
+        :param str logtofile: (kwarg) fully qualifed log file name ('')
+        :param int retries: (kwarg) maximum failed connection retries (5)
+        :param int retryinterval: (kwarg) retry interval in seconds (10)
+        :param int timeout: (kwarg) inactivity timeout in seconds (10)
         """
 
         # pylint: disable=consider-using-with
 
         self.__app = app  # Reference to calling application class (if applicable)
+        set_logging(
+            kwargs.pop("verbosity", VERBOSITY_MEDIUM), kwargs.pop("logtofile", "")
+        )
         self._validargs = True
-        self._loglines = 0
         self._ntripqueue = Queue()
         # persist settings to allow any calling app to retrieve them
         self._settings = {
@@ -120,23 +119,14 @@ class GNSSNTRIPClient:
         }
 
         try:
-            self._verbosity = int(kwargs.get("verbosity", VERBOSITY_MEDIUM))
-            self._logtofile = int(kwargs.get("logtofile", 0))
-            self._logpath = kwargs.get("logpath", ".")
-            self._clioutput = kwargs.pop("clioutput", OUTPUT_NONE)
-            # setup CLI output options
-            self._output = kwargs.get("output", None)
-            if isinstance(self._output, str):
-                if self._clioutput == OUTPUT_FILE:
-                    self._output = open(self._output, "wb")
-                elif self._clioutput == OUTPUT_SERIAL:
-                    port, baud = self._output.split("@")
-                    self._output = Serial(port, int(baud), timeout=3)
-
+            self._retries = max(int(kwargs.pop("retries", MAX_RETRY)), 0)
+            self._retryinterval = max(
+                int(kwargs.pop("retryinterval", RETRY_INTERVAL)), 1
+            )
+            self._timeout = max(int(kwargs.pop("timeout", INACTIVITY_TIMEOUT)), 3)
         except (ParameterError, ValueError, TypeError) as err:
-            self._do_log(
-                f"Invalid input arguments {kwargs}\n{err}\nType gnssntripclient -h for help.",
-                VERBOSITY_LOW,
+            logging.critical(
+                f"Invalid input arguments {kwargs=}\n{err=}\nType gnssntripclient -h for help.",
             )
             self._validargs = False
 
@@ -145,7 +135,7 @@ class GNSSNTRIPClient:
         self._stopevent = Event()
         self._ntrip_thread = None
         self._last_gga = datetime.fromordinal(1)
-        self._logfile = ""
+        self._retrycount = 0
 
     def __enter__(self):
         """
@@ -198,7 +188,7 @@ class GNSSNTRIPClient:
         use these instead of fixed reference coordinates.
 
         User login credentials can be obtained from environment variables
-        NTRIP_USER and NTRIP_PASSWORD, or passed as kwargs.
+        PYGPSCLIENT_USER and PYGPSCLIENT_PASSWORD, or passed as kwargs.
 
         :param str ipprot: (kwarg) IP protocol IPv4/IPv6 ("IPv4")
         :param str server: (kwarg) NTRIP server URL ("")
@@ -268,10 +258,8 @@ class GNSSNTRIPClient:
                 raise ParameterError(f"Invalid port {port}")
 
         except (ParameterError, ValueError, TypeError) as err:
-            self._do_log(
-                f"Invalid input arguments {kwargs}\n{err}\n"
-                + "Type gnssntripclient -h for help.",
-                VERBOSITY_LOW,
+            logging.critical(
+                f"Invalid input arguments {kwargs}\n{err}\nType gnssntripclient -h for help."
             )
             self._validargs = False
 
@@ -293,8 +281,6 @@ class GNSSNTRIPClient:
 
         self._stop_read_thread()
         self._connected = False
-        if self._clioutput in (OUTPUT_FILE, OUTPUT_SERIAL):
-            self._output.close()
 
     def _app_update_status(self, status: bool, msgt: tuple = None):
         """
@@ -381,9 +367,7 @@ class GNSSNTRIPClient:
                 "GGA",
                 GET,
                 lat=lat,
-                NS="S" if lat < 0 else "N",
                 lon=lon,
-                EW="W" if lon < 0 else "E",
                 quality=1,
                 numSV=15,
                 HDOP=0,
@@ -415,7 +399,7 @@ class GNSSNTRIPClient:
                 raw_data, parsed_data = self._formatGGA()
                 if parsed_data is not None:
                     self._socket.sendall(raw_data)
-                    self._do_write(output, raw_data, parsed_data)
+                    self._do_output(output, raw_data, parsed_data)
                 self._last_gga = datetime.now()
 
     def _get_closest_mountpoint(self) -> tuple:
@@ -435,9 +419,9 @@ class GNSSNTRIPClient:
             )
             if self._settings["mountpoint"] == "":
                 self._settings["mountpoint"] = closest_mp
-            self._do_log(
-                "Closest mountpoint to reference location "
-                + f"({lat}, {lon}) = {closest_mp}, {dist} km\n"
+            logging.info(
+                "Closest mountpoint to reference location"
+                f"({lat}, {lon}) = {closest_mp}, {dist} km."
             )
 
         except ValueError:
@@ -476,9 +460,81 @@ class GNSSNTRIPClient:
             self._stopevent.set()
             self._ntrip_thread = None
 
-        self._do_log("Streaming terminated\n")
+        logging.info("Streaming terminated.")
 
     def _read_thread(
+        self,
+        settings: dict,
+        stopevent: Event,
+        output: object,
+    ):
+        """
+        THREADED
+        Try connecting to NTRIP caster.
+
+        :param dict settings: settings as dictionary
+        :param Event stopevent: stop event
+        :param object output: output stream for raw data
+        """
+
+        self._retrycount = 0
+        server = settings["server"]
+        port = int(settings["port"])
+        mountpoint = settings["mountpoint"]
+
+        while self._retrycount <= self._retries and not stopevent.is_set():
+
+            try:
+
+                self._do_connection(settings, stopevent, output)
+
+            except ssl.SSLCertVerificationError as err:
+                tip = (
+                    f" - try using '{server[4:]}' rather than '{server}' for the NTRIP caster URL"
+                    if "certificate is not valid for 'www." in err.strerror
+                    else (
+                        f" - try adding the NTRIP caster URL SSL certificate to {findcacerts()}"
+                        if "unable to get local issuer certificate" in err.strerror
+                        else ""
+                    )
+                )
+                logging.error(f"SSL Certificate Verification Error{tip}\n{err}")
+                self._retrycount = self._retries
+                stopevent.set()
+                self._connected = False
+                self._app_update_status(False, (f"Error!: {err.strerror[0:60]}", "red"))
+
+            except (
+                BrokenPipeError,
+                ConnectionAbortedError,
+                ConnectionRefusedError,
+                ConnectionResetError,
+                OverflowError,
+                socket.gaierror,
+                ssl.SSLError,
+                TimeoutError,
+            ) as err:
+                errm = str(repr(err))
+                erra = f"Connection Error {errm.split('(', 1)[0]}"
+                errl = f"Error connecting to {server}:{port}/{mountpoint}: {errm}"
+                if self._retrycount == self._retries:
+                    stopevent.set()
+                    self._connected = False
+                    logging.critical(errl)
+                else:
+                    self._retrycount += 1
+                    errr = (
+                        f". Retrying in {self._retryinterval * self._retrycount} secs "
+                        f"({self._retrycount}/{self._retries}) ..."
+                    )
+                    erra += errr
+                    errl += errr
+                    logging.warning(errl)
+                self._app_update_status(False, (erra, "red"))
+
+            sleep(self._retryinterval * self._retrycount)
+
+    def _do_connection(
         self,
         settings: dict,
         stopevent: Event,
@@ -490,79 +546,56 @@ class GNSSNTRIPClient:
 
         :param dict settings: settings as dictionary
         :param Event stopevent: stop event
-        :param object output: output stream for RTCM3 data
+        :param object output: output stream for raw data
+        :raises: Various socket error types if connection fails
         """
 
-        try:
-            server = settings["server"]
-            port = int(settings["port"])
-            https = int(settings["https"])
-            flowinfo = int(settings["flowinfo"])
-            scopeid = int(settings["scopeid"])
-            mountpoint = settings["mountpoint"]
-            ggainterval = int(settings["ggainterval"])
-            datatype = settings["datatype"]
+        server = settings["server"]
+        port = int(settings["port"])
+        https = int(settings["https"])
+        flowinfo = int(settings["flowinfo"])
+        scopeid = int(settings["scopeid"])
+        mountpoint = settings["mountpoint"]
+        ggainterval = int(settings["ggainterval"])
+        datatype = settings["datatype"]
 
-            conn = format_conn(settings["ipprot"], server, port, flowinfo, scopeid)
-            with socket.socket(settings["ipprot"], socket.SOCK_STREAM) as self._socket:
-                if https:
-                    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-                    context.load_verify_locations(findcacerts())
-                    self._socket = context.wrap_socket(
-                        self._socket, server_hostname=server
+        conn = format_conn(settings["ipprot"], server, port, flowinfo, scopeid)
+        with socket.socket(settings["ipprot"], socket.SOCK_STREAM) as self._socket:
+            if https:
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                context.load_verify_locations(findcacerts())
+                self._socket = context.wrap_socket(self._socket, server_hostname=server)
+            self._socket.settimeout(TIMEOUT)
+            self._socket.connect(conn)
+            self._socket.sendall(self._formatGET(settings))
+            # send GGA sentence with request
+            if mountpoint != "":
+                self._send_GGA(ggainterval, output)
+            while not stopevent.is_set():
+                rc = self._do_header(self._socket, stopevent, output)
+                if rc == "0":  # streaming RTCM3/SPARTN data from mountpoint
+                    self._retrycount = 0
+                    msg = f"Streaming {datatype} data from {server}:{port}/{mountpoint} ..."
+                    logging.info(msg)
+                    self._app_update_status(True, (msg, "blue"))
+                    self._do_data(
+                        self._socket,
+                        datatype,
+                        stopevent,
+                        ggainterval,
+                        output,
                     )
-                self._socket.settimeout(TIMEOUT)
-                self._socket.connect(conn)
-                self._socket.sendall(self._formatGET(settings))
-                # send GGA sentence with request
-                if mountpoint != "":
-                    self._send_GGA(ggainterval, output)
-                while not stopevent.is_set():
-                    rc = self._do_header(self._socket, stopevent, output)
-                    if rc == "0":  # streaming RTMC3/SPARTN data from mountpoint
-                        self._do_log(
-                            f"Streaming {datatype} data from {server}:{port}/{mountpoint} ...\n"
-                        )
-                        self._do_data(
-                            self._socket,
-                            datatype,
-                            stopevent,
-                            ggainterval,
-                            output,
-                        )
-                    elif rc == "1":  # retrieved sourcetable
-                        stopevent.set()
-                        self._connected = False
-                        self._app_update_status(False)
-                    else:  # error message
-                        stopevent.set()
-                        self._connected = False
-                        self._app_update_status(False, (f"Error!: {rc}", "red"))
-        except (
-            socket.gaierror,
-            ConnectionRefusedError,
-            ConnectionAbortedError,
-            ConnectionResetError,
-            BrokenPipeError,
-            TimeoutError,
-            OverflowError,
-        ):
-            stopevent.set()
-            self._connected = False
-        except ssl.SSLCertVerificationError as err:
-            tip = (
-                f" - try using '{server[4:]}' rather than '{server}' for the NTRIP caster URL"
-                if "certificate is not valid for 'www." in err.strerror
-                else (
-                    f" - try adding the NTRIP caster URL SSL certificate to {findcacerts()}"
-                    if "unable to get local issuer certificate" in err.strerror
-                    else ""
-                )
-            )
-            print(f"SSL Certificate Verification Error{tip}\n{err}")
-            stopevent.set()
-            self._connected = False
-            self._app_update_status(False, (f"Error!: {err.strerror[0:32]}", "red"))
+                elif rc == "1":  # retrieved sourcetable
+                    stopevent.set()
+                    self._connected = False
+                    self._app_update_status(False, ("Sourcetable retrieved", "blue"))
+                else:  # error message
+                    logging.critical(
+                        f"Error connecting to {server}:{port}/{mountpoint=}: {rc}"
+                    )
+                    stopevent.set()
+                    self._connected = False
+                    self._app_update_status(False, (f"Error!: {rc}", "red"))
 
     def _do_header(self, sock: socket, stopevent: Event, output: object) -> str:
         """
@@ -585,7 +618,6 @@ class GNSSNTRIPClient:
                 for line in header_lines:
                     # if sourcetable request, populate list
                     if True in [line.find(cd) > 0 for cd in HTTPERR]:  # HTTP 40x
-                        self._do_log(line, VERBOSITY_MEDIUM, False)
                         return line
                     if line.find("STR;") >= 0:  # sourcetable entry
                         strbits = line.split(";")
@@ -595,10 +627,8 @@ class GNSSNTRIPClient:
                     elif line.find("ENDSOURCETABLE") >= 0:  # end of sourcetable
                         self._settings["sourcetable"] = stable
                         mp, dist = self._get_closest_mountpoint()
-                        self._do_write(output, stable, (mp, dist))
-                        self._do_log("Complete sourcetable follows...\n")
-                        for lines in self._settings["sourcetable"]:
-                            self._do_log(lines, VERBOSITY_MEDIUM, False)
+                        self._do_output(output, stable, (mp, dist))
+                        logging.info(f"Complete sourcetable follows...\n{stable}")
                         return "1"
 
             except UnicodeDecodeError:
@@ -616,18 +646,20 @@ class GNSSNTRIPClient:
     ):
         """
         THREADED
-        Read and parse incoming NTRIP RTCM3 data stream.
+        Read and parse incoming NTRIP RTCM3/SPARTN data stream.
 
         :param socket sock: socket
         :param str datatype: RTCM or SPARTN
         :param Event stopevent: stop event
         :param int ggainterval: GGA transmission interval seconds
-        :param object output: output stream for RTCM3 messages
+        :param object output: output stream for raw data
+        :raises: TimeoutError if inactivity timeout exceeded
         """
 
         parser = None
         raw_data = None
         parsed_data = None
+        last_activity = datetime.now()
 
         # parser will wrap socket as SocketStream
         if datatype == SPARTN:
@@ -651,8 +683,16 @@ class GNSSNTRIPClient:
         while not stopevent.is_set():
             try:
                 raw_data, parsed_data = parser.read()
-                if raw_data is not None:
-                    self._do_write(output, raw_data, parsed_data)
+                if raw_data is None:
+                    if datetime.now() - last_activity > timedelta(
+                        seconds=self._timeout
+                    ):
+                        raise TimeoutError(
+                            f"Inactivity timeout error after {self._timeout} seconds"
+                        )
+                else:
+                    self._do_output(output, raw_data, parsed_data)
+                    last_activity = datetime.now()
                 self._send_GGA(ggainterval, output)
 
             except (
@@ -664,25 +704,24 @@ class GNSSNTRIPClient:
                 SPARTNTypeError,
             ) as err:
                 parsed_data = f"Error parsing data stream {err}"
-                self._do_write(output, raw_data, parsed_data)
+                self._do_output(output, raw_data, parsed_data)
                 continue
 
-    def _do_write(self, output: object, raw: bytes, parsed: object):
+    def _do_output(self, output: object, raw: bytes, parsed: object):
         """
         THREADED
-        Send sourcetable/closest mountpoint or RTCM3 data to designated output medium.
+        Send sourcetable/closest mountpoint or RTCM3/SPARTN data to designated output medium.
 
         If output is Queue, will send both raw and parsed data.
 
-        :param object output: writeable output medium for RTCM3 data
+        :param object output: writeable output medium for raw data
         :param bytes raw: raw data
         :param object parsed: parsed message
         """
 
-        if self._clioutput in (OUTPUT_FILE, OUTPUT_SERIAL) and isinstance(output, str):
-            output = self._output
-
-        self._do_log(parsed, VERBOSITY_MEDIUM)
+        if hasattr(parsed, "identity"):
+            logging.info(parsed.identity)
+        logging.debug(parsed)
         if output is not None:
             # serialize sourcetable if outputting to stream
             if isinstance(raw, list) and not isinstance(output, Queue):
@@ -692,7 +731,7 @@ class GNSSNTRIPClient:
             elif isinstance(output, TextIOWrapper):
                 output.write(str(parsed))
             elif isinstance(output, Queue):
-                output.put((raw, parsed))
+                output.put(raw if self.__app == CLIAPP else (raw, parsed))
             elif isinstance(output, socket.socket):
                 output.sendall(raw)
 
@@ -717,238 +756,13 @@ class GNSSNTRIPClient:
                 srt += f"{col}{dlm}"
         return bytearray(srt, "utf-8")
 
-    def _do_log(
-        self,
-        message: object,
-        loglevel: int = VERBOSITY_MEDIUM,
-        timestamp: bool = True,
-    ):
+    @property
+    def stopevent(self) -> Event:
         """
-        THREADED
-        Write timestamped log message according to verbosity and logfile settings.
+        Getter for stop event.
 
-        :param object message: message or object to log
-        :param int loglevel: log level for this message (0,1,2)
-        :param bool timestamp: prefix message with timestamp (Y/N)
+        :return: stop event
+        :rtype: Event
         """
 
-        if timestamp:
-            message = f"{datetime.now()}: {str(message)}"
-        else:
-            message = str(message)
-
-        if self._verbosity >= loglevel:
-            if self._logtofile:
-                self._cycle_log()
-                with open(self._logfile, "a", encoding="UTF-8") as log:
-                    log.write(message + "\n")
-                    self._loglines += 1
-            else:
-                print(message)
-
-    def _cycle_log(self):
-        """
-        THREADED
-        Generate new timestamped logfile path.
-        """
-
-        if not self._loglines % LOGLIMIT:
-            tim = datetime.now().strftime("%Y%m%d%H%M%S")
-            self._logfile = path.join(self._logpath, f"gnssntripclient-{tim}.log")
-            self._loglines = 0
-
-
-def main():
-    """
-    CLI Entry point.
-
-    :param int waittime: response wait time in seconds (3)
-    :param: as per GNSSNTRIPClient constructor and run() method.
-    :raises: ParameterError if parameters are invalid
-    """
-    # pylint: disable=raise-missing-from
-
-    ap = ArgumentParser(
-        epilog=EPILOG,
-        formatter_class=ArgumentDefaultsHelpFormatter,
-    )
-    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
-    ap.add_argument(
-        "-I",
-        "--ipprot",
-        required=False,
-        help="IP protocol",
-        choices=["IPv4", "IPv6"],
-        default="IPv4",
-    )
-    ap.add_argument(
-        "-S", "--server", required=True, help="NTRIP server (caster) URL", default=""
-    )
-    ap.add_argument(
-        "-P", "--port", required=False, help="NTRIP port", type=int, default=2101
-    )
-    ap.add_argument(
-        "--https",
-        required=False,
-        help=(
-            f"HTTPS (TLS) connection? 0 = HTTP, "
-            "1 = HTTPS (defaults to 1 if port in {DEFAULT_TLS_PORTS})"
-        ),
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    ap.add_argument(
-        "--flowinfo", required=False, help="Flow info for IPv6", type=int, default=0
-    )
-    ap.add_argument(
-        "--scopeid", required=False, help="Scope ID for IPv6", type=int, default=0
-    )
-    ap.add_argument(
-        "-M",
-        "--mountpoint",
-        required=False,
-        help="NTRIP mountpoint (leave blank to get sourcetable)",
-        default="",
-    )
-    ap.add_argument(
-        "--ntripversion",
-        required=False,
-        dest="version",
-        help="NTRIP protocol version",
-        default="2.0",
-    )
-    ap.add_argument(
-        "--datatype",
-        required=False,
-        help="Data type (RTCM or SPARTN)",
-        choices=[RTCM, "rtcm", SPARTN, "spartn"],
-        default=RTCM,
-    )
-    ap.add_argument(
-        "--waittime",
-        required=False,
-        help="Response wait time",
-        type=int,
-        default=3,
-    )
-    ap.add_argument(
-        "--ntripuser",
-        required=False,
-        help="NTRIP authentication user",
-        default=getenv("PYGPSCLIENT_USER", "anon"),
-    )
-    ap.add_argument(
-        "--ntrippassword",
-        required=False,
-        help="NTRIP authentication password",
-        default=getenv("PYGPSCLIENT_PASSWORD", "password"),
-    )
-    ap.add_argument(
-        "--ggainterval",
-        required=False,
-        help="GGA sentence transmission interval (-1 = None)",
-        type=int,
-        default=-1,
-    )
-    ap.add_argument(
-        "--ggamode",
-        required=False,
-        help="GGA pos source; 0 = live from receiver, 1 = fixed reference",
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    ap.add_argument(
-        "--reflat", required=False, help="reference latitude", type=float, default=0.0
-    )
-    ap.add_argument(
-        "--reflon", required=False, help="reference longitude", type=float, default=0.0
-    )
-    ap.add_argument(
-        "--refalt", required=False, help="reference altitude", type=float, default=0.0
-    )
-    ap.add_argument(
-        "--refsep", required=False, help="reference separation", type=float, default=0.0
-    )
-    ap.add_argument(
-        "--spartndecode",
-        required=False,
-        help="Decode SPARTN payload?",
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    ap.add_argument(
-        "--spartnkey",
-        required=False,
-        help="Decryption key for encrypted SPARTN payloads",
-        default=getenv("MQTTKEY", default=None),
-    )
-    ap.add_argument(
-        "--spartnbasedate",
-        required=False,
-        help="Decryption basedate for encrypted SPARTN payloads",
-        default=datetime.now(timezone.utc),
-    )
-    ap.add_argument(
-        "--verbosity",
-        required=False,
-        help="Log message verbosity 0 = low, 1 = medium, 2 = high, 3 = debug",
-        type=int,
-        choices=[0, 1, 2, 3],
-        default=1,
-    )
-    ap.add_argument(
-        "--logtofile",
-        required=False,
-        help="0 = log to stdout, 1 = log to file '/logpath/gnssntripclient-timestamp.log'",
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    ap.add_argument(
-        "--logpath",
-        required=False,
-        help="Fully qualified path to logfile folder",
-        default=".",
-    )
-    ap.add_argument(
-        "--clioutput",
-        required=False,
-        help="CLI output type 0 = none, 1 = binary file, 2 = serial port",
-        type=int,
-        choices=[0, 1, 2],
-        default=0,
-    )
-    ap.add_argument(
-        "--output",
-        required=False,
-        help=(
-            "Output medium (if clioutput=1, format='/full/path/data.log'; "
-            "if clioutput=2, format='/dev/tty.ACM0@38400' "
-            "NB: gnssntripclient will have exclusive use of this port)"
-        ),
-        default=None,
-    )
-
-    args = ap.parse_args()
-    kwargs = vars(args)
-
-    # assume HTTPS if port is 443 or 2102 (PointPerfect NTRIP TLS port)
-    kwargs["https"] = 1 if kwargs["port"] in DEFAULT_TLS_PORTS else kwargs["https"]
-
-    try:
-        with GNSSNTRIPClient(None, **kwargs) as gnc:
-            streaming = gnc.run(**kwargs)
-
-            while streaming:  # run until user presses CTRL-C
-                sleep(args.waittime)
-            sleep(args.waittime)
-
-    except KeyboardInterrupt:
-        pass
-
-
-if __name__ == "__main__":
-    main()
+        return self._stopevent

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -90,7 +90,9 @@ class GNSSNTRIPClient:
 
         self.__app = app  # Reference to calling application class (if applicable)
         set_logging(
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM), kwargs.pop("logtofile", "")
+            logger,
+            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
+            kwargs.pop("logtofile", ""),
         )
         self._validargs = True
         self._ntripqueue = Queue()
@@ -722,7 +724,7 @@ class GNSSNTRIPClient:
         """
 
         if hasattr(parsed, "identity"):
-            logger.info(parsed.identity)
+            logger.info(f"{type(parsed).__name__} received: {parsed.identity}")
         logger.debug(parsed)
         if output is not None:
             # serialize sourcetable if outputting to stream

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -66,6 +66,8 @@ RETRY_INTERVAL = 10
 INACTIVITY_TIMEOUT = 10
 WAITTIME = 3
 
+logger = logging.getLogger(__name__)
+
 
 class GNSSNTRIPClient:
     """
@@ -125,7 +127,7 @@ class GNSSNTRIPClient:
             )
             self._timeout = max(int(kwargs.pop("timeout", INACTIVITY_TIMEOUT)), 3)
         except (ParameterError, ValueError, TypeError) as err:
-            logging.critical(
+            logger.critical(
                 f"Invalid input arguments {kwargs=}\n{err=}\nType gnssntripclient -h for help.",
             )
             self._validargs = False
@@ -258,7 +260,7 @@ class GNSSNTRIPClient:
                 raise ParameterError(f"Invalid port {port}")
 
         except (ParameterError, ValueError, TypeError) as err:
-            logging.critical(
+            logger.critical(
                 f"Invalid input arguments {kwargs}\n{err}\nType gnssntripclient -h for help."
             )
             self._validargs = False
@@ -419,7 +421,7 @@ class GNSSNTRIPClient:
             )
             if self._settings["mountpoint"] == "":
                 self._settings["mountpoint"] = closest_mp
-            logging.info(
+            logger.info(
                 "Closest mountpoint to reference location"
                 f"({lat}, {lon}) = {closest_mp}, {dist} km."
             )
@@ -460,7 +462,7 @@ class GNSSNTRIPClient:
             self._stopevent.set()
             self._ntrip_thread = None
 
-        logging.info("Streaming terminated.")
+        logger.info("Streaming terminated.")
 
     def _read_thread(
         self,
@@ -498,7 +500,7 @@ class GNSSNTRIPClient:
                         else ""
                     )
                 )
-                logging.error(f"SSL Certificate Verification Error{tip}\n{err}")
+                logger.error(f"SSL Certificate Verification Error{tip}\n{err}")
                 self._retrycount = self._retries
                 stopevent.set()
                 self._connected = False
@@ -520,7 +522,7 @@ class GNSSNTRIPClient:
                 if self._retrycount == self._retries:
                     stopevent.set()
                     self._connected = False
-                    logging.critical(errl)
+                    logger.critical(errl)
                 else:
                     self._retrycount += 1
                     errr = (
@@ -529,7 +531,7 @@ class GNSSNTRIPClient:
                     )
                     erra += errr
                     errl += errr
-                    logging.warning(errl)
+                    logger.warning(errl)
                 self._app_update_status(False, (erra, "red"))
 
             sleep(self._retryinterval * self._retrycount)
@@ -576,7 +578,7 @@ class GNSSNTRIPClient:
                 if rc == "0":  # streaming RTCM3/SPARTN data from mountpoint
                     self._retrycount = 0
                     msg = f"Streaming {datatype} data from {server}:{port}/{mountpoint} ..."
-                    logging.info(msg)
+                    logger.info(msg)
                     self._app_update_status(True, (msg, "blue"))
                     self._do_data(
                         self._socket,
@@ -590,7 +592,7 @@ class GNSSNTRIPClient:
                     self._connected = False
                     self._app_update_status(False, ("Sourcetable retrieved", "blue"))
                 else:  # error message
-                    logging.critical(
+                    logger.critical(
                         f"Error connecting to {server}:{port}/{mountpoint=}: {rc}"
                     )
                     stopevent.set()
@@ -628,7 +630,7 @@ class GNSSNTRIPClient:
                         self._settings["sourcetable"] = stable
                         mp, dist = self._get_closest_mountpoint()
                         self._do_output(output, stable, (mp, dist))
-                        logging.info(f"Complete sourcetable follows...\n{stable}")
+                        logger.info(f"Complete sourcetable follows...\n{stable}")
                         return "1"
 
             except UnicodeDecodeError:
@@ -720,8 +722,8 @@ class GNSSNTRIPClient:
         """
 
         if hasattr(parsed, "identity"):
-            logging.info(parsed.identity)
-        logging.debug(parsed)
+            logger.info(parsed.identity)
+        logger.debug(parsed)
         if output is not None:
             # serialize sourcetable if outputting to stream
             if isinstance(raw, list) and not isinstance(output, Queue):

--- a/src/pygnssutils/gnssntripclient_cli.py
+++ b/src/pygnssutils/gnssntripclient_cli.py
@@ -1,0 +1,292 @@
+"""
+gnssntripclient_cli.py
+
+CLI wrapper for GNSSNTRIPClient class.
+
+Created on 24 Jul 2024
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2022
+:license: BSD 3-Clause
+"""
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from datetime import datetime, timezone
+from os import getenv
+from queue import Queue
+from threading import Thread
+from time import sleep
+
+from serial import Serial
+
+from pygnssutils._version import __version__ as VERSION
+from pygnssutils.globals import (
+    CLIAPP,
+    DEFAULT_TLS_PORTS,
+    EPILOG,
+    OUTPUT_FILE,
+    OUTPUT_NONE,
+    OUTPUT_SERIAL,
+    OUTPUT_SOCKET,
+    VERBOSITY_DEBUG,
+    VERBOSITY_HIGH,
+    VERBOSITY_LOW,
+    VERBOSITY_MEDIUM,
+)
+from pygnssutils.gnssntripclient import (
+    GGAFIXED,
+    GGALIVE,
+    INACTIVITY_TIMEOUT,
+    MAX_RETRY,
+    RETRY_INTERVAL,
+    RTCM,
+    SPARTN,
+    WAITTIME,
+    GNSSNTRIPClient,
+)
+from pygnssutils.socket_server import runserver
+
+
+def runclient(**kwargs):
+    """
+    Start NTRIP client with CLI parameters.
+    """
+
+    with GNSSNTRIPClient(CLIAPP, **kwargs) as gnc:
+        gnc.run(**kwargs)
+        # run until stop event or user presses CTRL-C
+        while not gnc.stopevent.is_set():
+            sleep(WAITTIME)
+        sleep(0.5)
+
+
+def main():
+    """
+    CLI Entry point.
+
+    :param: as per GNSSNTRIPClient constructor and run() method.
+    :raises: ParameterError if parameters are invalid
+    """
+    # pylint: disable=raise-missing-from, too-many-statements
+
+    ap = ArgumentParser(
+        epilog=EPILOG,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    ap.add_argument(
+        "-S", "--server", required=True, help="NTRIP server (caster) URL", default=""
+    )
+    ap.add_argument(
+        "-P", "--port", required=False, help="NTRIP port", type=int, default=2101
+    )
+    ap.add_argument(
+        "-M",
+        "--mountpoint",
+        required=False,
+        help="NTRIP mountpoint (leave blank to get sourcetable)",
+        default="",
+    )
+    ap.add_argument(
+        "-H",
+        "--https",
+        required=False,
+        help=(
+            f"HTTPS (TLS) connection? 0 = HTTP, "
+            f"1 = HTTPS (defaults to 1 if port in {DEFAULT_TLS_PORTS})"
+        ),
+        type=int,
+        choices=[0, 1],
+        default=0,
+    )
+    ap.add_argument(
+        "-I",
+        "--ipprot",
+        required=False,
+        help="IP protocol",
+        choices=["IPv4", "IPv6"],
+        default="IPv4",
+    )
+    ap.add_argument(
+        "--flowinfo", required=False, help="Flow info for IPv6", type=int, default=0
+    )
+    ap.add_argument(
+        "--scopeid", required=False, help="Scope ID for IPv6", type=int, default=0
+    )
+    ap.add_argument(
+        "--retries",
+        required=False,
+        help="Maximum failed connection retries",
+        type=int,
+        default=MAX_RETRY,
+    )
+    ap.add_argument(
+        "--retryinterval",
+        required=False,
+        help="Retry interval in seconds (* retries)",
+        type=int,
+        default=RETRY_INTERVAL,
+    )
+    ap.add_argument(
+        "--timeout",
+        required=False,
+        help="Inactivity timeout in seconds",
+        type=int,
+        default=INACTIVITY_TIMEOUT,
+    )
+    ap.add_argument(
+        "--ntripversion",
+        required=False,
+        dest="version",
+        help="NTRIP protocol version",
+        default="2.0",
+    )
+    ap.add_argument(
+        "--datatype",
+        required=False,
+        help="Data type (RTCM or SPARTN)",
+        choices=[RTCM, "rtcm", SPARTN, "spartn"],
+        default=RTCM,
+    )
+    ap.add_argument(
+        "--ntripuser",
+        required=False,
+        help="NTRIP authentication user",
+        default=getenv("PYGPSCLIENT_USER", "anon"),
+    )
+    ap.add_argument(
+        "--ntrippassword",
+        required=False,
+        help="NTRIP authentication password",
+        default=getenv("PYGPSCLIENT_PASSWORD", "password"),
+    )
+    ap.add_argument(
+        "--ggainterval",
+        required=False,
+        help="GGA NMEA sentence transmission interval (-1 = None)",
+        type=int,
+        default=-1,
+    )
+    ap.add_argument(
+        "--ggamode",
+        required=False,
+        help=f"GGA pos source; {GGALIVE} = live from receiver, {GGAFIXED} = fixed reference",
+        type=int,
+        choices=[GGALIVE, GGAFIXED],
+        default=GGAFIXED,
+    )
+    ap.add_argument(
+        "--reflat", required=False, help="reference latitude", type=float, default=0.0
+    )
+    ap.add_argument(
+        "--reflon", required=False, help="reference longitude", type=float, default=0.0
+    )
+    ap.add_argument(
+        "--refalt", required=False, help="reference altitude", type=float, default=0.0
+    )
+    ap.add_argument(
+        "--refsep", required=False, help="reference separation", type=float, default=0.0
+    )
+    ap.add_argument(
+        "--spartndecode",
+        required=False,
+        help="Decode SPARTN payload?",
+        type=int,
+        choices=[0, 1],
+        default=0,
+    )
+    ap.add_argument(
+        "--spartnkey",
+        required=False,
+        help="Decryption key for encrypted SPARTN payloads",
+        default=getenv("MQTTKEY", default=None),
+    )
+    ap.add_argument(
+        "--spartnbasedate",
+        required=False,
+        help="Decryption basedate for encrypted SPARTN payloads",
+        default=datetime.now(timezone.utc),
+    )
+    ap.add_argument(
+        "--verbosity",
+        required=False,
+        help=(
+            f"Log message verbosity {VERBOSITY_LOW} = low (error, critical), "
+            f"{VERBOSITY_MEDIUM} = medium (warning), "
+            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+        ),
+        type=int,
+        choices=[VERBOSITY_LOW, VERBOSITY_MEDIUM, VERBOSITY_HIGH, VERBOSITY_DEBUG],
+        default=VERBOSITY_MEDIUM,
+    )
+    ap.add_argument(
+        "--logtofile",
+        required=False,
+        help="fully qualified log file name, or '' for no log file",
+        type=str,
+        default="",
+    )
+    ap.add_argument(
+        "--clioutput",
+        required=False,
+        help=(
+            f"CLI output type {OUTPUT_NONE} = none, "
+            f"{OUTPUT_FILE} = binary file, "
+            f"{OUTPUT_SERIAL} = serial port, "
+            f"{OUTPUT_SOCKET} = TCP socket server"
+        ),
+        type=int,
+        choices=[OUTPUT_NONE, OUTPUT_FILE, OUTPUT_SERIAL, OUTPUT_SOCKET],
+        default=OUTPUT_NONE,
+    )
+    ap.add_argument(
+        "--output",
+        required=False,
+        help=(
+            f"Output medium as formatted string. "
+            f"If clioutput = {OUTPUT_FILE}, format = file name (e.g. '/home/myuser/rtcm.log'); "
+            f"If clioutput = {OUTPUT_SERIAL}, format = port@baudrate (e.g. '/dev/tty.ACM0@38400'); "
+            f"If clioutput = {OUTPUT_SOCKET}, format = hostip:port (e.g. '0.0.0.0:50010'). "
+            "NB: gnssntripclient will have exclusive use of any serial or server port."
+        ),
+        default=None,
+    )
+
+    args = ap.parse_args()
+    kwargs = vars(args)
+
+    # assume HTTPS if port is 443 or 2102 (PointPerfect NTRIP TLS port)
+    kwargs["https"] = 1 if kwargs["port"] in DEFAULT_TLS_PORTS else kwargs["https"]
+
+    cliout = kwargs.pop("clioutput", OUTPUT_NONE)
+    try:
+        if cliout == OUTPUT_FILE:
+            filename = kwargs["output"]
+            with open(filename, "wb") as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SERIAL:
+            port, baud = kwargs["output"].split("@")
+            with Serial(port, int(baud), timeout=3) as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SOCKET:
+            host, port = kwargs["output"].split(":")
+            kwargs["output"] = Queue()
+            # socket server runs as background thread, piping
+            # output from ntrip client via a message queue
+            Thread(
+                target=runserver,
+                args=(host, int(port), kwargs["output"]),
+                daemon=True,
+            ).start()
+            runclient(**kwargs)
+        else:
+            kwargs["output"] = None
+            runclient(**kwargs)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -32,6 +32,8 @@ from pygnssutils.gnssstreamer import GNSSStreamer
 from pygnssutils.helpers import format_conn, ipprot2int, set_logging
 from pygnssutils.socket_server import ClientHandler, SocketServer
 
+logger = logging.getLogger(__name__)
+
 
 class GNSSSocketServer:
     """
@@ -111,7 +113,7 @@ class GNSSSocketServer:
             self._validargs = True
 
         except ValueError as err:
-            logging.critical(f"Invalid input arguments {kwargs}\n{err}")
+            logger.critical(f"Invalid input arguments {kwargs}\n{err}")
             self._validargs = False
 
     def __enter__(self):
@@ -139,7 +141,7 @@ class GNSSSocketServer:
         """
 
         if self._validargs:
-            logging.info("Starting server (type CTRL-C to stop)...")
+            logger.info("Starting server (type CTRL-C to stop)...")
             self._in_thread = self._start_input_thread(**self._kwargs)
             sleep(0.5)
             if self._in_thread.is_alive():
@@ -154,12 +156,12 @@ class GNSSSocketServer:
         Shutdown server.
         """
 
-        logging.info("Stopping server...")
+        logger.info("Stopping server...")
         if self._streamer is not None:
             self._streamer.stop()
         if self._socket_server is not None:
             self._socket_server.shutdown()
-        logging.info("Server shutdown.")
+        logger.info("Server shutdown.")
 
     def _start_input_thread(self, **kwargs) -> Thread:
         """
@@ -170,7 +172,7 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        logging.info(f"Starting input thread, reading from {kwargs['port']}...")
+        logger.info(f"Starting input thread, reading from {kwargs['port']}...")
         thread = Thread(
             target=self._input_thread,
             args=(kwargs,),
@@ -188,7 +190,7 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        logging.info(
+        logger.info(
             f"Starting output thread, broadcasting on {kwargs['hostip']}:{kwargs['outport']}..."
         )
         thread = Thread(
@@ -236,7 +238,7 @@ class GNSSSocketServer:
             ) as self._socket_server:
                 self._socket_server.serve_forever()
         except OSError as err:
-            logging.critical(f"Error starting socket server {err}")
+            logger.critical(f"Error starting socket server {err}")
 
     def notify_client(self, address: tuple, status: int):
         """
@@ -253,6 +255,6 @@ class GNSSSocketServer:
         else:
             pre = "dis"
             self._clients -= 1
-        logging.info(
+        logger.info(
             f"Client {address} has {pre}connected. Total clients: {self._clients}"
         )

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -76,7 +76,9 @@ class GNSSSocketServer:
         # Reference to calling application class (if applicable)
         self.__app = app  # pylint: disable=unused-private-member
         set_logging(
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM), kwargs.pop("logtofile", "")
+            logger,
+            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
+            kwargs.pop("logtofile", ""),
         )
         try:
             self._kwargs = kwargs

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -16,26 +16,20 @@ Created on 24 May 2022
 
 # pylint: disable=too-many-arguments
 
-import os
-from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from datetime import datetime
+import logging
 from queue import Queue
 from threading import Thread
 from time import sleep
 
-from pygnssutils._version import __version__ as VERSION
 from pygnssutils.globals import (
     CONNECTED,
-    EPILOG,
     FORMAT_BINARY,
-    LOGLIMIT,
     OUTPORT,
     OUTPORT_NTRIP,
-    VERBOSITY_LOW,
     VERBOSITY_MEDIUM,
 )
-from pygnssutils.gnssdump import GNSSStreamer
-from pygnssutils.helpers import format_conn, ipprot2int
+from pygnssutils.gnssstreamer import GNSSStreamer
+from pygnssutils.helpers import format_conn, ipprot2int, set_logging
 from pygnssutils.socket_server import ClientHandler, SocketServer
 
 
@@ -46,7 +40,7 @@ class GNSSSocketServer:
 
     # pylint: disable=line-too-long
 
-    def __init__(self, **kwargs):
+    def __init__(self, app=None, **kwargs):
         """
         Context manager constructor.
 
@@ -74,10 +68,14 @@ class GNSSSocketServer:
         :param str msgfilter: (kwarg) comma-separated string of message identities e.g. 'NAV-PVT,GNGSA' (None)
         :param int limit: (kwarg) maximum number of messages to read (0 = unlimited)
         :param int verbosity: (kwarg) log message verbosity 0 = low, 1 = medium, 3 = high (1)
-        :param int logtofile: (kwarg) 0 = log to stdout, 1 = log to file '/logpath/gnssserver-timestamp.log' (0)
-        :param int logpath: {kwarg} fully qualified path to logfile folder (".")
+        :param str logtofile: (kwarg) fully qualifed log file name ('')
         """
 
+        # Reference to calling application class (if applicable)
+        self.__app = app  # pylint: disable=unused-private-member
+        set_logging(
+            kwargs.pop("verbosity", VERBOSITY_MEDIUM), kwargs.pop("logtofile", "")
+        )
         try:
             self._kwargs = kwargs
             # overrideable command line arguments..
@@ -102,9 +100,6 @@ class GNSSSocketServer:
             # 5 is an arbitrary limit; could be significantly higher
             self._kwargs["maxclients"] = int(kwargs.get("maxclients", 5))
             self._kwargs["format"] = int(kwargs.get("format", FORMAT_BINARY))
-            self._kwargs["verbosity"] = int(kwargs.get("verbosity", VERBOSITY_MEDIUM))
-            self._kwargs["logtofile"] = int(kwargs.get("logtofile", 0))
-            self._kwargs["logpath"] = kwargs.get("logpath", ".")
             # required fixed arguments...
             msgqueue = Queue()
             self._kwargs["outputhandler"] = msgqueue
@@ -114,15 +109,9 @@ class GNSSSocketServer:
             self._out_thread = None
             self._clients = 0
             self._validargs = True
-            self._logpath = ""
-            self._logfile = ""
-            self._loglines = 0
 
         except ValueError as err:
-            self._do_log(
-                f"Invalid input arguments {kwargs}\n{err}",
-                VERBOSITY_LOW,
-            )
+            logging.critical(f"Invalid input arguments {kwargs}\n{err}")
             self._validargs = False
 
     def __enter__(self):
@@ -150,7 +139,7 @@ class GNSSSocketServer:
         """
 
         if self._validargs:
-            self._do_log("Starting server (type CTRL-C to stop)...", VERBOSITY_MEDIUM)
+            logging.info("Starting server (type CTRL-C to stop)...")
             self._in_thread = self._start_input_thread(**self._kwargs)
             sleep(0.5)
             if self._in_thread.is_alive():
@@ -165,12 +154,12 @@ class GNSSSocketServer:
         Shutdown server.
         """
 
-        self._do_log("Stopping server...", VERBOSITY_MEDIUM)
+        logging.info("Stopping server...")
         if self._streamer is not None:
             self._streamer.stop()
         if self._socket_server is not None:
             self._socket_server.shutdown()
-        self._do_log("Server shutdown.", VERBOSITY_MEDIUM)
+        logging.info("Server shutdown.")
 
     def _start_input_thread(self, **kwargs) -> Thread:
         """
@@ -181,9 +170,7 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        self._do_log(
-            f"Starting input thread, reading from {kwargs['port']}...", VERBOSITY_MEDIUM
-        )
+        logging.info(f"Starting input thread, reading from {kwargs['port']}...")
         thread = Thread(
             target=self._input_thread,
             args=(kwargs,),
@@ -201,9 +188,8 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        self._do_log(
-            f"Starting output thread, broadcasting on {kwargs['hostip']}:{kwargs['outport']}...",
-            VERBOSITY_MEDIUM,
+        logging.info(
+            f"Starting output thread, broadcasting on {kwargs['hostip']}:{kwargs['outport']}..."
         )
         thread = Thread(
             target=self._output_thread,
@@ -250,7 +236,7 @@ class GNSSSocketServer:
             ) as self._socket_server:
                 self._socket_server.serve_forever()
         except OSError as err:
-            self._do_log(f"Error starting socket server {err}", VERBOSITY_MEDIUM)
+            logging.critical(f"Error starting socket server {err}")
 
     def notify_client(self, address: tuple, status: int):
         """
@@ -267,242 +253,6 @@ class GNSSSocketServer:
         else:
             pre = "dis"
             self._clients -= 1
-        self._do_log(
-            f"Client {address} has {pre}connected. Total clients: {self._clients}",
-            VERBOSITY_MEDIUM,
+        logging.info(
+            f"Client {address} has {pre}connected. Total clients: {self._clients}"
         )
-
-    def _do_log(
-        self,
-        message: str,
-        loglevel: int = VERBOSITY_MEDIUM,
-    ):
-        """
-        Write timestamped log message according to verbosity and logfile settings.
-
-        :param str message: message to log
-        :param int loglevel: log level for this message (0,1,2)
-        """
-
-        msg = f"{datetime.now()}: {message}"
-        if self._kwargs["verbosity"] >= loglevel:
-            if self._kwargs["logtofile"]:
-                self._cycle_log()
-                with open(self._logfile, "a", encoding="utf-8") as log:
-                    log.write(msg + "\n")
-                    self._loglines += 1
-            else:
-                print(msg)
-
-    def _cycle_log(self):
-        """
-        Generate new timestamped logfile path.
-        """
-
-        if not self._loglines % LOGLIMIT:
-            tim = datetime.now().strftime("%Y%m%d%H%M%S")
-            self._logfile = os.path.join(
-                self._kwargs["logpath"], f"gnssserver-{tim}.log"
-            )
-            self._loglines = 0
-
-
-def main():
-    """
-    CLI Entry point.
-
-    :param int waittime: response wait time in seconds (1)
-    :param: as per NSSSocketServer constructor.
-    """
-
-    arp = ArgumentParser(
-        epilog=EPILOG,
-        formatter_class=ArgumentDefaultsHelpFormatter,
-    )
-    arp.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
-    arp.add_argument("-I", "--inport", required=False, help="Input serial port")
-    arp.add_argument("-S", "--socket", required=False, help="Input socket host:port")
-    arp.add_argument(
-        "-O",
-        "--outport",
-        required=False,
-        help="Output TCP port",
-        type=int,
-        default=50010,
-    )
-    arp.add_argument(
-        "--ipprot",
-        required=False,
-        help="IP protocol",
-        choices=["IPv4", "IPv6"],
-        default="IPv4",
-    )
-    arp.add_argument(
-        "-H",
-        "--hostip",
-        required=False,
-        help="Host IP Address Binding (0.0.0.0/:: = all)",
-        default="0.0.0.0",
-    )
-    arp.add_argument(
-        "-N",
-        "--ntripmode",
-        required=False,
-        help="NTRIP Mode 0 = socket server, 1 = NTRIP caster",
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    arp.add_argument(
-        "--ntripuser",
-        required=False,
-        type=str,
-        help="NTRIP caster authentication user",
-        default=os.getenv("PYGPSCLIENT_USER", "anon"),
-    )
-    arp.add_argument(
-        "--ntrippassword",
-        required=False,
-        type=str,
-        help="NTRIP caster authentication password",
-        default=os.getenv("PYGPSCLIENT_PASSWORD", "password"),
-    )
-    arp.add_argument(
-        "--baudrate",
-        required=False,
-        help="Serial baud rate",
-        type=int,
-        choices=[4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800],
-        default=9600,
-    )
-    arp.add_argument(
-        "--timeout",
-        required=False,
-        help="Serial timeout in seconds",
-        type=float,
-        default=3.0,
-    )
-    arp.add_argument(
-        "--format",
-        required=False,
-        help="Output format 1 = parsed, 2 = binary, 4 = hex, 8 = tabulated hex,"
-        + "16 = parsed as string, 32 = JSON (can be OR'd)",
-        type=int,
-        default=2,
-    )
-    arp.add_argument(
-        "-v",
-        "--validate",
-        required=False,
-        help="1 = validate checksums, 0 = do not validate",
-        type=int,
-        choices=[0, 1],
-        default=1,
-    )
-    arp.add_argument(
-        "--msgmode",
-        required=False,
-        help="0 = GET, 1 = SET, 2 = POLL",
-        type=int,
-        choices=[0, 1, 2],
-        default=0,
-    )
-    arp.add_argument(
-        "--maxclients",
-        required=False,
-        help="Maximum number of clients",
-        type=int,
-        choices=range(1, 21),
-        default=5,
-    )
-    arp.add_argument(
-        "--parsebitfield",
-        required=False,
-        help="1 = parse UBX 'X' attributes as bitfields, 0 = leave as bytes",
-        type=int,
-        choices=[0, 1],
-        default=1,
-    )
-    arp.add_argument(
-        "--quitonerror",
-        required=False,
-        help="0 = ignore errors,  1 = log errors and continue, 2 = (re)raise errors",
-        type=int,
-        choices=[0, 1, 2],
-        default=1,
-    )
-    arp.add_argument(
-        "--protfilter",
-        required=False,
-        help="1 = NMEA, 2 = UBX, 4 = RTCM3 (can be OR'd)",
-        type=int,
-        default=7,
-    )
-    arp.add_argument(
-        "--msgfilter",
-        required=False,
-        help="Comma-separated string of message identities e.g. 'NAV-PVT,GNGSA'",
-        default=None,
-    )
-    arp.add_argument(
-        "--limit",
-        required=False,
-        help="Maximum number of messages to read (0 = unlimited)",
-        type=int,
-        default=0,
-    )
-    arp.add_argument(
-        "--verbosity",
-        required=False,
-        help="Log message verbosity 0 = low, 1 = medium, 2 = high, 3 = debug",
-        type=int,
-        choices=[0, 1, 2, 3],
-        default=1,
-    )
-    arp.add_argument(
-        "--outfile",
-        required=False,
-        help="Fully qualified path to output file",
-        default=None,
-    )
-    arp.add_argument(
-        "--waittime",
-        required=False,
-        help="Response wait time",
-        type=int,
-        default=1,
-    )
-    arp.add_argument(
-        "--logtofile",
-        required=False,
-        help="0 = log to stdout, 1 = log to file '/logpath/gnssserver-timestamp.log'",
-        type=int,
-        choices=[0, 1],
-        default=0,
-    )
-    arp.add_argument(
-        "--logpath",
-        required=False,
-        help="Fully qualified path to logfile folder",
-        default=".",
-    )
-
-    args = arp.parse_args()
-    kwargs = vars(args)
-    if kwargs["hostip"] == "0.0.0.0" and kwargs["ipprot"] == "IPv6":
-        kwargs["hostip"] = "::"
-
-    try:
-        with GNSSSocketServer(**kwargs) as server:
-            goodtogo = server.run()
-
-            while goodtogo:  # run until user presses CTRL-C
-                sleep(args.waittime)
-            sleep(args.waittime)
-
-    except KeyboardInterrupt:
-        pass
-
-
-if __name__ == "__main__":
-    main()

--- a/src/pygnssutils/gnssserver_cli.py
+++ b/src/pygnssutils/gnssserver_cli.py
@@ -15,7 +15,14 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from time import sleep
 
 from pygnssutils._version import __version__ as VERSION
-from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.globals import (
+    CLIAPP,
+    EPILOG,
+    VERBOSITY_DEBUG,
+    VERBOSITY_HIGH,
+    VERBOSITY_LOW,
+    VERBOSITY_MEDIUM,
+)
 from pygnssutils.gnssserver import GNSSSocketServer
 
 
@@ -166,10 +173,14 @@ def main():
     ap.add_argument(
         "--verbosity",
         required=False,
-        help="Log message verbosity 0 = low, 1 = medium, 2 = high, 3 = debug",
+        help=(
+            f"Log message verbosity {VERBOSITY_LOW} = low (error, critical), "
+            f"{VERBOSITY_MEDIUM} = medium (warning), "
+            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+        ),
         type=int,
-        choices=[0, 1, 2, 3],
-        default=1,
+        choices=[VERBOSITY_LOW, VERBOSITY_MEDIUM, VERBOSITY_HIGH, VERBOSITY_DEBUG],
+        default=VERBOSITY_MEDIUM,
     )
     ap.add_argument(
         "--outfile",

--- a/src/pygnssutils/gnssserver_cli.py
+++ b/src/pygnssutils/gnssserver_cli.py
@@ -1,0 +1,213 @@
+"""
+gnssserver_cli.py
+
+CLI wrapper for GNSSSocketServer class.
+
+Created on 24 Jul 2024
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2022
+:license: BSD 3-Clause
+"""
+
+import os
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from time import sleep
+
+from pygnssutils._version import __version__ as VERSION
+from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.gnssserver import GNSSSocketServer
+
+
+def main():
+    """
+    CLI Entry point.
+
+    :param int waittime: response wait time in seconds (1)
+    :param: as per NSSSocketServer constructor.
+    """
+
+    ap = ArgumentParser(
+        epilog=EPILOG,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    ap.add_argument("-I", "--inport", required=False, help="Input serial port")
+    ap.add_argument("-S", "--socket", required=False, help="Input socket host:port")
+    ap.add_argument(
+        "-O",
+        "--outport",
+        required=False,
+        help="Output TCP port",
+        type=int,
+        default=50010,
+    )
+    ap.add_argument(
+        "--ipprot",
+        required=False,
+        help="IP protocol",
+        choices=["IPv4", "IPv6"],
+        default="IPv4",
+    )
+    ap.add_argument(
+        "-H",
+        "--hostip",
+        required=False,
+        help="Host IP Address Binding (0.0.0.0/:: = all)",
+        default="0.0.0.0",
+    )
+    ap.add_argument(
+        "-N",
+        "--ntripmode",
+        required=False,
+        help="NTRIP Mode 0 = socket server, 1 = NTRIP caster",
+        type=int,
+        choices=[0, 1],
+        default=0,
+    )
+    ap.add_argument(
+        "--ntripuser",
+        required=False,
+        type=str,
+        help="NTRIP caster authentication user",
+        default=os.getenv("PYGPSCLIENT_USER", "anon"),
+    )
+    ap.add_argument(
+        "--ntrippassword",
+        required=False,
+        type=str,
+        help="NTRIP caster authentication password",
+        default=os.getenv("PYGPSCLIENT_PASSWORD", "password"),
+    )
+    ap.add_argument(
+        "--baudrate",
+        required=False,
+        help="Serial baud rate",
+        type=int,
+        choices=[4800, 9600, 19200, 38400, 57600, 115200, 230400, 460800],
+        default=9600,
+    )
+    ap.add_argument(
+        "--timeout",
+        required=False,
+        help="Serial timeout in seconds",
+        type=float,
+        default=3.0,
+    )
+    ap.add_argument(
+        "--format",
+        required=False,
+        help="Output format 1 = parsed, 2 = binary, 4 = hex, 8 = tabulated hex,"
+        + "16 = parsed as string, 32 = JSON (can be OR'd)",
+        type=int,
+        default=2,
+    )
+    ap.add_argument(
+        "-v",
+        "--validate",
+        required=False,
+        help="1 = validate checksums, 0 = do not validate",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--msgmode",
+        required=False,
+        help="0 = GET, 1 = SET, 2 = POLL",
+        type=int,
+        choices=[0, 1, 2],
+        default=0,
+    )
+    ap.add_argument(
+        "--maxclients",
+        required=False,
+        help="Maximum number of clients",
+        type=int,
+        choices=range(1, 21),
+        default=5,
+    )
+    ap.add_argument(
+        "--parsebitfield",
+        required=False,
+        help="1 = parse UBX 'X' attributes as bitfields, 0 = leave as bytes",
+        type=int,
+        choices=[0, 1],
+        default=1,
+    )
+    ap.add_argument(
+        "--quitonerror",
+        required=False,
+        help="0 = ignore errors,  1 = log errors and continue, 2 = (re)raise errors",
+        type=int,
+        choices=[0, 1, 2],
+        default=1,
+    )
+    ap.add_argument(
+        "--protfilter",
+        required=False,
+        help="1 = NMEA, 2 = UBX, 4 = RTCM3 (can be OR'd)",
+        type=int,
+        default=7,
+    )
+    ap.add_argument(
+        "--msgfilter",
+        required=False,
+        help="Comma-separated string of message identities e.g. 'NAV-PVT,GNGSA'",
+        default=None,
+    )
+    ap.add_argument(
+        "--limit",
+        required=False,
+        help="Maximum number of messages to read (0 = unlimited)",
+        type=int,
+        default=0,
+    )
+    ap.add_argument(
+        "--verbosity",
+        required=False,
+        help="Log message verbosity 0 = low, 1 = medium, 2 = high, 3 = debug",
+        type=int,
+        choices=[0, 1, 2, 3],
+        default=1,
+    )
+    ap.add_argument(
+        "--outfile",
+        required=False,
+        help="Fully qualified path to output file",
+        default=None,
+    )
+    ap.add_argument(
+        "--waittime",
+        required=False,
+        help="Response wait time",
+        type=int,
+        default=1,
+    )
+    ap.add_argument(
+        "--logtofile",
+        required=False,
+        help="fully qualified log file name, or '' for no log file",
+        type=str,
+        default="",
+    )
+
+    args = ap.parse_args()
+    kwargs = vars(args)
+    if kwargs["hostip"] == "0.0.0.0" and kwargs["ipprot"] == "IPv6":
+        kwargs["hostip"] = "::"
+
+    try:
+        with GNSSSocketServer(CLIAPP, **kwargs) as server:
+            goodtogo = server.run()
+
+            while goodtogo:  # run until user presses CTRL-C
+                sleep(args.waittime)
+            sleep(args.waittime)
+
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pygnssutils/gnssstreamer.py
+++ b/src/pygnssutils/gnssstreamer.py
@@ -107,7 +107,7 @@ class GNSSStreamer:
         # Reference to calling application class (if applicable)
         self.__app = app  # pylint: disable=unused-private-member
         set_logging(
-            kwargs.pop("verbosity", VERBOSITY_HIGH), kwargs.pop("logtofile", "")
+            logger, kwargs.pop("verbosity", VERBOSITY_HIGH), kwargs.pop("logtofile", "")
         )
         self._reader = None
         self.ctx_mgr = False

--- a/src/pygnssutils/gnssstreamer.py
+++ b/src/pygnssutils/gnssstreamer.py
@@ -52,6 +52,8 @@ from pygnssutils.globals import (
 )
 from pygnssutils.helpers import format_conn, format_json, ipprot2int, set_logging
 
+logger = logging.getLogger(__name__)
+
 
 class GNSSStreamer:
     """
@@ -292,13 +294,13 @@ class GNSSStreamer:
             f"Messages output:   {dict(sorted(self._outcount.items()))}",
         ]
         for msg in msgs:
-            logging.info(msg)
+            logger.info(msg)
 
         msg = (
             f"Streaming terminated, {self._msgcount:,} message{mss} "
             f"processed with {self._errcount:,} error{ers}."
         )
-        logging.info(msg)
+        logger.info(msg)
 
         if self._output is not None:
             self._output.close()
@@ -314,7 +316,7 @@ class GNSSStreamer:
             msgmode=self._msgmode,
             parsebitfield=self._parsebitfield,
         )
-        logging.info(f"Parsing GNSS data stream from: {self._stream}...")
+        logger.info(f"Parsing GNSS data stream from: {self._stream}...")
 
         # if outputting json, add opening tag
         if self._format == FORMAT_JSON:
@@ -414,7 +416,7 @@ class GNSSStreamer:
                     return False
                 toc = time()
                 elapsed = toc - tic
-                logging.debug(f"Time since last {identity} message was sent: {elapsed}")
+                logger.debug(f"Time since last {identity} message was sent: {elapsed}")
                 # check if at least 95% of filter period has elapsed
                 if elapsed >= 0.95 * per:
                     self._msgfilter[identity] = (per, toc)
@@ -502,7 +504,7 @@ class GNSSStreamer:
             if self._quitonerror == ERR_RAISE:
                 raise err
             if self._quitonerror == ERR_LOG:
-                print(err)
+                logger.critical(err)
         elif isinstance(self._errorhandler, (Serial, BufferedWriter)):
             self._errorhandler.write(err)
         elif isinstance(self._errorhandler, TextIOWrapper):

--- a/src/pygnssutils/helpers.py
+++ b/src/pygnssutils/helpers.py
@@ -18,23 +18,29 @@ from socket import AF_INET, AF_INET6, gaierror, getaddrinfo
 from pynmeagps import haversine
 from pyubx2 import itow2utc
 
-from pygnssutils.globals import LOGGING_LEVELS, LOGLIMIT, VERBOSITY_MEDIUM
+from pygnssutils.globals import LOGFORMAT, LOGGING_LEVELS, LOGLIMIT, VERBOSITY_MEDIUM
 
 
 def set_logging(
-    logger: logging.Logger, verbosity: int = VERBOSITY_MEDIUM, logtofile: str = ""
+    logger: logging.Logger,
+    verbosity: int = VERBOSITY_MEDIUM,
+    logtofile: str = "",
+    format: str = LOGFORMAT,
+    limit: int = LOGLIMIT,
 ):
     """
     Set logging format and level.
 
     :param logging.Logger logger: module log handler
-    :param int verbosity: verbosity level 0-3 (2 = MEDIUM/WARNING)
-    :param str logtofile: fully qualified log file name ("")
+    :param int verbosity: verbosity level 0-3
+    :param str logtofile: fully qualified log file name
+    :param str format: logging format
+    :param int max: maximum logfile size in bytes
     """
 
     logger.setLevel(logging.DEBUG)
     logformat = logging.Formatter(
-        "{asctime}.{msecs:.0f} - {levelname} - {name} - {message}",
+        format,
         datefmt="%Y-%m-%d %H:%M:%S",
         style="{",
     )
@@ -42,7 +48,7 @@ def set_logging(
         loghandler = logging.StreamHandler()
     else:
         loghandler = logging.handlers.RotatingFileHandler(
-            logtofile, mode="a", maxBytes=LOGLIMIT, backupCount=10, encoding="utf-8"
+            logtofile, mode="a", maxBytes=limit, backupCount=10, encoding="utf-8"
         )
     loghandler.setFormatter(logformat)
     loghandler.setLevel(LOGGING_LEVELS[int(verbosity)])

--- a/src/pygnssutils/helpers.py
+++ b/src/pygnssutils/helpers.py
@@ -10,11 +10,35 @@ Created on 26 May 2022
 
 # pylint: disable=invalid-name
 
+from logging import basicConfig
 from math import cos, radians, sin
 from socket import AF_INET, AF_INET6, gaierror, getaddrinfo
 
 from pynmeagps import haversine
 from pyubx2 import itow2utc
+
+from pygnssutils.globals import LOGGING_LEVELS, VERBOSITY_MEDIUM
+
+
+def set_logging(verbosity: int = VERBOSITY_MEDIUM, logtofile: str = ""):
+    """
+    Set logging format and level.
+    """
+
+    kwargs = {
+        "level": LOGGING_LEVELS[int(verbosity)],
+        "format": "{asctime}.{msecs:.0f} - {levelname} - {message}",
+        "datefmt": "%Y-%m-%d %H:%M:%S",
+        "style": "{",
+    }
+    if logtofile != "":
+        kwargs = {
+            **kwargs,
+            "filename": logtofile,
+            "encoding": "utf-8",
+            "filemode": "a",
+        }
+    basicConfig(**kwargs)
 
 
 def get_mp_distance(lat: float, lon: float, mp: list) -> float:

--- a/src/pygnssutils/ubxsimulator.py
+++ b/src/pygnssutils/ubxsimulator.py
@@ -125,7 +125,7 @@ class UBXSimulator:
             with open(cfile, "r", encoding="utf-8") as jsonfile:
                 config = load(jsonfile)
         except (OSError, JSONDecodeError) as err:
-            print(f"{datetime.now()} - Unable to read configuration file:\n{err}")
+            logger.error(f"Unable to read configuration file:\n{err}")
             return {
                 "interval": DEFAULT_INTERVAL,
                 "timeout": DEFAULT_TIMEOUT,

--- a/src/pygnssutils/ubxsimulator_cli.py
+++ b/src/pygnssutils/ubxsimulator_cli.py
@@ -15,7 +15,14 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from pyubx2 import UBXReader
 
 from pygnssutils._version import __version__ as VERSION
-from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.globals import (
+    CLIAPP,
+    EPILOG,
+    VERBOSITY_DEBUG,
+    VERBOSITY_HIGH,
+    VERBOSITY_LOW,
+    VERBOSITY_MEDIUM,
+)
 from pygnssutils.ubxsimulator import DEFAULT_PATH, UBXSimulator
 
 
@@ -24,13 +31,13 @@ def main():
     CLI Entry point.
     """
 
-    arp = ArgumentParser(
+    ap = ArgumentParser(
         description="pygnssutils EXPERIMENTAL UBX Serial Device Simulator",
         epilog=EPILOG,
         formatter_class=ArgumentDefaultsHelpFormatter,
     )
-    arp.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
-    arp.add_argument(
+    ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    ap.add_argument(
         "-I",
         "--interval",
         required=False,
@@ -38,7 +45,7 @@ def main():
         help="Simulated navigation interval in seconds (Hz = 1/interval)",
         default=1,
     )
-    arp.add_argument(
+    ap.add_argument(
         "-T",
         "--timeout",
         required=False,
@@ -46,7 +53,7 @@ def main():
         help="Simulated serial read timeout in seconds",
         default=3,
     )
-    arp.add_argument(
+    ap.add_argument(
         "-C",
         "--configfile",
         required=False,
@@ -54,8 +61,27 @@ def main():
         help="Fully qualified path to json configuration file",
         default=DEFAULT_PATH + ".json",
     )
+    ap.add_argument(
+        "--verbosity",
+        required=False,
+        help=(
+            f"Log message verbosity {VERBOSITY_LOW} = low (error, critical), "
+            f"{VERBOSITY_MEDIUM} = medium (warning), "
+            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+        ),
+        type=int,
+        choices=[VERBOSITY_LOW, VERBOSITY_MEDIUM, VERBOSITY_HIGH, VERBOSITY_DEBUG],
+        default=VERBOSITY_MEDIUM,
+    )
+    ap.add_argument(
+        "--logtofile",
+        required=False,
+        help="fully qualified log file name, or '' for no log file",
+        type=str,
+        default="",
+    )
 
-    kwargs = vars(arp.parse_args())
+    kwargs = vars(ap.parse_args())
 
     with UBXSimulator(CLIAPP, **kwargs) as stream:
 

--- a/src/pygnssutils/ubxsimulator_cli.py
+++ b/src/pygnssutils/ubxsimulator_cli.py
@@ -1,0 +1,74 @@
+"""
+ubxsimulator_cli.py
+
+CLI wrapper for UBXSimulator class.
+
+Created on 24 Jul 2024
+
+:author: semuadmin
+:copyright: SEMU Consulting © 2024
+:license: BSD 3-Clause
+"""
+
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+
+from pyubx2 import UBXReader
+
+from pygnssutils._version import __version__ as VERSION
+from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.ubxsimulator import DEFAULT_PATH, UBXSimulator
+
+
+def main():
+    """
+    CLI Entry point.
+    """
+
+    arp = ArgumentParser(
+        description="pygnssutils EXPERIMENTAL UBX Serial Device Simulator",
+        epilog=EPILOG,
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    arp.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
+    arp.add_argument(
+        "-I",
+        "--interval",
+        required=False,
+        type=float,
+        help="Simulated navigation interval in seconds (Hz = 1/interval)",
+        default=1,
+    )
+    arp.add_argument(
+        "-T",
+        "--timeout",
+        required=False,
+        type=float,
+        help="Simulated serial read timeout in seconds",
+        default=3,
+    )
+    arp.add_argument(
+        "-C",
+        "--configfile",
+        required=False,
+        type=str,
+        help="Fully qualified path to json configuration file",
+        default=DEFAULT_PATH + ".json",
+    )
+
+    kwargs = vars(arp.parse_args())
+
+    with UBXSimulator(CLIAPP, **kwargs) as stream:
+
+        try:
+            ubr = UBXReader(stream)
+            i = 0
+            for _, parsed in ubr:
+                print(parsed)
+                i += 1
+        except KeyboardInterrupt:
+            print(f"Terminated by user, {i} messages read")
+
+
+if __name__ == "__main__":
+
+    main()

--- a/tests/test_gnssdump.py
+++ b/tests/test_gnssdump.py
@@ -5,6 +5,7 @@ Created on 3 Oct 2020
 
 @author: semuadmin
 """
+
 # pylint: disable=line-too-long, invalid-name, missing-docstring, no-member
 
 import os
@@ -13,7 +14,7 @@ import unittest
 from io import StringIO
 
 from pygnssutils import exceptions as pge
-from pygnssutils.gnssdump import (
+from pygnssutils.gnssstreamer import (
     FORMAT_BINARY,
     FORMAT_HEX,
     FORMAT_HEXTABLE,

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -7,8 +7,10 @@ Created on 26 May 2022
 
 @author: semuadmin
 """
+
 # pylint: disable=line-too-long, invalid-name, missing-docstring, no-member
 
+import logging
 import os
 import sys
 import unittest
@@ -43,54 +45,48 @@ class StreamTest(unittest.TestCase):
 
     def testnofilter(self):  # test gnssdump with no message filter
         EXPECTED_OUTPUT1 = (
-            "Streaming terminated, 5,941 messages processed with 0 errors."
+            "INFO:root:Streaming terminated, 5,941 messages processed with 0 errors."
         )
-        EXPECTED_OUTPUT2 = "Messages output:   {'1005': 158, '1077': 158, '1087': 158, '1097': 158, '1127': 158, '1230': 158, '4072': 158, 'GAGSV': 628, 'GBGSV': 720, 'GLGSV': 628, 'GNGGA': 157, 'GNGLL': 158, 'GNGSA': 785, 'GNRMC': 157, 'GNVTG': 157, 'GPGSV': 1114, 'GQGSV': 157, 'NAV-PVT': 158, 'NAV-SVIN': 16}"
-        dirname = os.path.dirname(__file__)
-        filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+        EXPECTED_OUTPUT2 = "INFO:root:Messages output:   {'1005': 158, '1077': 158, '1087': 158, '1097': 158, '1127': 158, '1230': 158, '4072': 158, 'GAGSV': 628, 'GBGSV': 720, 'GLGSV': 628, 'GNGGA': 157, 'GNGLL': 158, 'GNGSA': 785, 'GNRMC': 157, 'GNVTG': 157, 'GPGSV': 1114, 'GQGSV': 157, 'NAV-PVT': 158, 'NAV-SVIN': 16}"
         self.catchio()
-        gns = GNSSStreamer(filename=filename, verbosity=2)
-        gns.run()
-        output = self.restoreio().split("\n")
-        out1 = output[-1][28:]
-        out2 = output[-2][28:]
-        self.assertEqual(out1, EXPECTED_OUTPUT1)
-        self.assertEqual(out2, EXPECTED_OUTPUT2)
-        # print(out1, out2)
+        with self.assertLogs(level=logging.INFO) as log:
+            dirname = os.path.dirname(__file__)
+            filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+            gns = GNSSStreamer(filename=filename, verbosity=2)
+            gns.run()
+        self.assertEqual(log.output[-1], EXPECTED_OUTPUT1)
+        self.assertEqual(log.output[-2], EXPECTED_OUTPUT2)
+        self.restoreio()
 
     def testfilter(self):  # test gnssdump with message filter
-        EXPECTED_OUTPUT1 = "Streaming terminated, 316 messages processed with 0 errors."
-        EXPECTED_OUTPUT2 = "Messages output:   {'1077': 158, '1087': 158}"
-        dirname = os.path.dirname(__file__)
-        filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+        EXPECTED_OUTPUT1 = (
+            "INFO:root:Streaming terminated, 316 messages processed with 0 errors."
+        )
+        EXPECTED_OUTPUT2 = "INFO:root:Messages output:   {'1077': 158, '1087': 158}"
         self.catchio()
-        gns = GNSSStreamer(filename=filename, verbosity=2, msgfilter="1077,1087")
-        gns.run()
-        output = self.restoreio().split("\n")
-        out1 = output[-1][28:]
-        out2 = output[-2][28:]
-        self.assertEqual(out1, EXPECTED_OUTPUT1)
-        self.assertEqual(out2, EXPECTED_OUTPUT2)
-        # print(out1, out2)
+        with self.assertLogs(level=logging.INFO) as log:
+            dirname = os.path.dirname(__file__)
+            filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+            gns = GNSSStreamer(filename=filename, verbosity=2, msgfilter="1077,1087")
+            gns.run()
+        self.assertEqual(log.output[-1], EXPECTED_OUTPUT1)
+        self.assertEqual(log.output[-2], EXPECTED_OUTPUT2)
+        self.restoreio()
 
     def testfilterperiod(self):  # test gnssdump with message period filter
-        EXPECTED_OUTPUT1 = (
-            r"Streaming terminated, [0-9][0-9][0-9] messages processed with 0 errors."
-        )
-        EXPECTED_OUTPUT2 = r"Messages output:   {'1077': [0-9]?[0-9], '1087': [0-9]?[0-9], '1097': [0-9][0-9][0-9]}"
-        dirname = os.path.dirname(__file__)
-        filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+        EXPECTED_OUTPUT1 = r"INFO:root:Streaming terminated, [0-9][0-9][0-9] messages processed with 0 errors."
+        EXPECTED_OUTPUT2 = r"INFO:root:Messages output:   {'1077': [0-9]?[0-9], '1087': [0-9]?[0-9], '1097': [0-9][0-9][0-9]}"
         self.catchio()
-        gns = GNSSStreamer(
-            filename=filename, verbosity=2, msgfilter="1077(.05),1087(.05),1097"
-        )
-        gns.run()
-        output = self.restoreio().split("\n")
-        out1 = output[-1][28:]
-        out2 = output[-2][28:]
-        self.assertRegex(out1, EXPECTED_OUTPUT1)
-        self.assertRegex(out2, EXPECTED_OUTPUT2)
-        # print(out1, out2)
+        with self.assertLogs(level=logging.INFO) as log:
+            dirname = os.path.dirname(__file__)
+            filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
+            gns = GNSSStreamer(
+                filename=filename, verbosity=2, msgfilter="1077(.05),1087(.05),1097"
+            )
+            gns.run()
+        self.assertRegex(log.output[-1], EXPECTED_OUTPUT1)
+        self.assertRegex(log.output[-2], EXPECTED_OUTPUT2)
+        self.restoreio()
 
 
 if __name__ == "__main__":

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -44,25 +44,22 @@ class StreamTest(unittest.TestCase):
         return self._strout.getvalue().strip()
 
     def testnofilter(self):  # test gnssdump with no message filter
-        EXPECTED_OUTPUT1 = (
-            "INFO:root:Streaming terminated, 5,941 messages processed with 0 errors."
-        )
-        EXPECTED_OUTPUT2 = "INFO:root:Messages output:   {'1005': 158, '1077': 158, '1087': 158, '1097': 158, '1127': 158, '1230': 158, '4072': 158, 'GAGSV': 628, 'GBGSV': 720, 'GLGSV': 628, 'GNGGA': 157, 'GNGLL': 158, 'GNGSA': 785, 'GNRMC': 157, 'GNVTG': 157, 'GPGSV': 1114, 'GQGSV': 157, 'NAV-PVT': 158, 'NAV-SVIN': 16}"
+        EXPECTED_OUTPUT1 = "INFO:pygnssutils.gnssstreamer:Streaming terminated, 5,941 messages processed with 0 errors."
+        EXPECTED_OUTPUT2 = "INFO:pygnssutils.gnssstreamer:Messages output:   {'1005': 158, '1077': 158, '1087': 158, '1097': 158, '1127': 158, '1230': 158, '4072': 158, 'GAGSV': 628, 'GBGSV': 720, 'GLGSV': 628, 'GNGGA': 157, 'GNGLL': 158, 'GNGSA': 785, 'GNRMC': 157, 'GNVTG': 157, 'GPGSV': 1114, 'GQGSV': 157, 'NAV-PVT': 158, 'NAV-SVIN': 16}"
         self.catchio()
         with self.assertLogs(level=logging.INFO) as log:
             dirname = os.path.dirname(__file__)
             filename = os.path.join(dirname, "pygpsdata-rtcm3.log")
             gns = GNSSStreamer(filename=filename, verbosity=2)
             gns.run()
+        # print(log.output[-1], log.output[-2])
         self.assertEqual(log.output[-1], EXPECTED_OUTPUT1)
         self.assertEqual(log.output[-2], EXPECTED_OUTPUT2)
         self.restoreio()
 
     def testfilter(self):  # test gnssdump with message filter
-        EXPECTED_OUTPUT1 = (
-            "INFO:root:Streaming terminated, 316 messages processed with 0 errors."
-        )
-        EXPECTED_OUTPUT2 = "INFO:root:Messages output:   {'1077': 158, '1087': 158}"
+        EXPECTED_OUTPUT1 = "INFO:pygnssutils.gnssstreamer:Streaming terminated, 316 messages processed with 0 errors."
+        EXPECTED_OUTPUT2 = "INFO:pygnssutils.gnssstreamer:Messages output:   {'1077': 158, '1087': 158}"
         self.catchio()
         with self.assertLogs(level=logging.INFO) as log:
             dirname = os.path.dirname(__file__)
@@ -74,8 +71,8 @@ class StreamTest(unittest.TestCase):
         self.restoreio()
 
     def testfilterperiod(self):  # test gnssdump with message period filter
-        EXPECTED_OUTPUT1 = r"INFO:root:Streaming terminated, [0-9][0-9][0-9] messages processed with 0 errors."
-        EXPECTED_OUTPUT2 = r"INFO:root:Messages output:   {'1077': [0-9]?[0-9], '1087': [0-9]?[0-9], '1097': [0-9][0-9][0-9]}"
+        EXPECTED_OUTPUT1 = r"INFO:pygnssutils.gnssstreamer:Streaming terminated, [0-9][0-9][0-9] messages processed with 0 errors."
+        EXPECTED_OUTPUT2 = r"INFO:pygnssutils.gnssstreamer:Messages output:   {'1077': [0-9]?[0-9], '1087': [0-9]?[0-9], '1097': [0-9][0-9][0-9]}"
         self.catchio()
         with self.assertLogs(level=logging.INFO) as log:
             dirname = os.path.dirname(__file__)


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. Add automated network connection timeout and retry to gnssntripclient - new CLI arguments `--retries`, `--retryinterval`, `--timeout`. See `gnssntripclient -h` for help.
1. Add TCP socket server output option to gnssntripclient and gnssmqttclient  - new CLI argument `--cliout 3`.
1. Refactor utilties to use standard Python logging module - `--verbosity` arguments are now mapped to logging levels (0 low => error, critical; 1 medium => warning; 2 high => info; 3 debug => debug).
1. Refactor utilities to use separate `*_cli.py` module for command line argument parsing.

Fixes #73

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] streaming tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
