### PR TITLE
update NMEA GGA sent to the ntrip caster with number of satellite, RTK fix status, and age of differential

### DIFF
--- a/examples/gnssapp.py
+++ b/examples/gnssapp.py
@@ -196,6 +196,9 @@ class GNSSSkeletonApp:
             self.fix = FIXTYPE[parsed_data.fixType]
         if hasattr(parsed_data, "carrSoln"):
             self.fix = f"{self.fix} {CARRSOLN[parsed_data.carrSoln]}"
+            self.rtk = parsed_data.carrSoln
+        if hasattr(parsed_data, "lastCorrectionAge"):
+            self.age = parsed_data.lastCorrectionAge
         if hasattr(parsed_data, "numSV"):
             self.siv = parsed_data.numSV
         if hasattr(parsed_data, "lat"):
@@ -272,7 +275,7 @@ class GNSSSkeletonApp:
         :rtype: tuple
         """
 
-        return (self.connected, self.lat, self.lon, self.alt, self.sep)
+        return (self.connected, self.lat, self.lon, self.alt, self.sep, self.siv, self.rtk, self.age)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

The current ntrip client sends a NMEA GGA with a fake number of satellite (15), always SPP for GNSS solution type, and always 0 for age of differential, instead of the real-time GNSS solution status from the receiver. 

Fixes # (issue)

## Testing

Pass the test for test_gnssdump.py.

## Checklist:

- [X] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [X] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [X] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [X ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [X] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [X] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [X] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
