### PR TITLE
RELEASE CANDIDATE 1.0.32

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "python3.8InterpreterPath": "/Library/Frameworks/Python.framework/Versions/3.8/bin/python3.8",
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.31"
+    "moduleversion": "1.0.32"
 }

--- a/README.md
+++ b/README.md
@@ -318,15 +318,24 @@ For help and full list of optional arguments, type:
 
 ### EXPERIMENTAL
 
-Provides a simple simulation of a GNSS serial stream by generating synthetic UBX or NMEA messages based on parameters defined in a json configuration file. Can simulate a motion vector based on a specified course over ground and speed.
+Provides a simple simulation of a GNSS serial stream by generating synthetic UBX or NMEA messages based on parameters defined in a json configuration file. Can simulate a motion vector based on a specified course over ground and speed. Location of configuration file can be set via environment variable `UBXSIMULATOR`.
 
-Example usage::
+Example usage:
+
+```shell
+ubxsimulator --simconfigfile "/home/myuser/ubxsimulator.json" --interval 1000 --timeout 3 --verbosity 3
+```
 
 ```python
-from pygnssutils import UBXSimulator
+from os import getenv
+from pygnssutils import UBXSimulator, UBXSIMULATOR
 from pyubx2 import UBXReader
 
-with UBXSimulator(configfile="/home/myuser/ubxsimulator.json", interval=1, timeout=3) as stream:
+with UBXSimulator(
+    configfile=getenv(UBXSIMULATOR, "/home/myuser/ubxsimulator.json"),
+    interval=1000,
+    timeout=3,
+) as stream:
     ubr = UBXReader(stream)
     for raw, parsed in ubr:
         print(parsed)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 
 ENHANCEMENTS:
 
-1. Add configuration file option to all CLI utilities via `-C` or `--config` argument. Config files are text files containing key-value pairs which mirror the existing CLI arguments, e.g. 
+1. Add configuration file option to all CLI utilities via `-C` or `--config` argument. Default location of configuration file can be specified in environment variable `{utility}_CONF` e.g. `GNSSDUMP_CONF`, `GNSSNTRIPCLIENT_CONF`, etc. Config files are text files containing key-value pairs which mirror the existing CLI arguments, e.g.
 ```shell
 gnssdump -C gnssdump.conf
 ```

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,34 @@
 # pygnssutils Release Notes
 
+### RELEASE 1.0.32
+
+ENHANCEMENTS:
+
+1. Add configuration file option to all CLI utilities via `-C` or `--config` argument. Config files are text files containing key-value pairs which mirror the existing CLI arguments, e.g. 
+```shell
+gnssdump -C gnssdump.conf
+```
+where gnssdump.conf contains...
+
+    filename=pygpsdata-MIXED3.log
+    verbosity=3
+    format=2
+    clioutput=1
+    output=testfile.bin
+
+is equivalent to: 
+```shell
+gnssdump --filename pygpsdata-MIXED3.log --verbosity 3 --format 2 --clioutput 1 --output testfile.bin
+```
+2. Streamline logging. CLI usage unchanged; to use pygnssutils logging within calling application, invoke `logging.getLogger("pygnssutils")` in calling module.
+3. Internal enhancements to experimental UBXSimulator to add close() and in_waiting() methods; recognise incoming RTCM data.
+4. GGA message sent to NTRIP Caster in GGALIVE mode will include additional live attributes (siv, hdop, quality, diffage, diffstation). Thanks to @yydgis for contribution.
+
+FIXES:
+
+1. gnssntripclient - update HTTP GET request for better NTRIP 2.0 compliance
+1. issue with delay on gnssntripclient retry limit
+
 ### RELEASE 1.0.31
 
 ENHANCEMENTS:

--- a/examples/gnssapp.py
+++ b/examples/gnssapp.py
@@ -29,15 +29,14 @@ Created on 27 Jul 2023
 :license: BSD 3-Clause
 """
 
-# pylint: disable=invalid-name, too-many-instance-attributes
-
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from logging import getLogger
 from queue import Empty, Queue
 from threading import Event, Thread
 from time import sleep
 
 from pynmeagps import NMEAMessageError, NMEAParseError
-from pyrtcm import RTCMMessage, RTCMMessageError, RTCMParseError
+from pyrtcm import RTCMMessageError, RTCMParseError
 from pyubx2 import (
     CARRSOLN,
     FIXTYPE,
@@ -51,8 +50,32 @@ from pyubx2 import (
 )
 from serial import Serial
 
+from pygnssutils import VERBOSITY_MEDIUM, UBXSimulator, set_common_args
+
 DISCONNECTED = 0
 CONNECTED = 1
+FIXTYPE_GGA = {
+    0: "NO FIX",
+    1: "3D",
+    2: "3D",
+    4: "RTK FIXED",
+    5: "RTK FLOAT",
+    6: "DR",
+}
+DIFFAGE_PVT = {
+    0: 0,
+    1: 1,
+    2: 2,
+    3: 5,
+    4: 10,
+    5: 15,
+    6: 20,
+    7: 30,
+    8: 45,
+    9: 60,
+    10: 90,
+    11: 120,
+}
 
 
 class GNSSSkeletonApp:
@@ -72,13 +95,15 @@ class GNSSSkeletonApp:
         :param Event stopevent: stop event
         """
 
+        self.verbosity = kwargs.get("verbosity", VERBOSITY_MEDIUM)
+        # configure logger with name "pygnssutils" in calling module
+        self.logger = getLogger("pygnssutils.gnssapp")
         self.port = port
         self.baudrate = baudrate
         self.timeout = timeout
         self.stopevent = stopevent
         self.recvqueue = kwargs.get("recvqueue", None)
         self.sendqueue = kwargs.get("sendqueue", None)
-        self.verbosity = kwargs.get("verbosity", 1)
         self.enableubx = kwargs.get("enableubx", True)
         self.showstatus = kwargs.get("showstatus", True)
         self.stream = None
@@ -90,6 +115,11 @@ class GNSSSkeletonApp:
         self.alt = 0
         self.sep = 0
         self.hacc = 0
+        self.sip = 0
+        self.fix = "NO FIX"
+        self.hdop = 0
+        self.diffage = 0
+        self.diffstation = 0
 
     def __enter__(self):
         """
@@ -112,9 +142,16 @@ class GNSSSkeletonApp:
         Run GNSS reader/writer.
         """
 
+        self.logger.info("Starting GNSS reader/writer...")
         self.enable_ubx(self.enableubx)
 
-        self.stream = Serial(self.port, self.baudrate, timeout=self.timeout)
+        if self.port == "UBXSIMULATOR":
+            self.stream = UBXSimulator(
+                configfile="ubxsimulator.json", interval=1000, timeout=3
+            )
+            self.stream.start()
+        else:
+            self.stream = Serial(self.port, self.baudrate, timeout=self.timeout)
         self.connected = CONNECTED
         self.stopevent.clear()
 
@@ -139,6 +176,7 @@ class GNSSSkeletonApp:
         self.connected = DISCONNECTED
         if self.stream is not None:
             self.stream.close()
+        self.logger.info("GNSS reader/writer stopped")
 
     def _read_loop(
         self, stream: Serial, stopevent: Event, recvqueue: Queue, sendqueue: Queue
@@ -163,10 +201,8 @@ class GNSSSkeletonApp:
                     raw_data, parsed_data = ubr.read()
                     if parsed_data:
                         self._extract_data(parsed_data)
-                        if self.verbosity == 1:
-                            print(f"GNSS>> {parsed_data.identity}")
-                        elif self.verbosity == 2:
-                            print(parsed_data)
+                        self.logger.info(f"GNSS>> {parsed_data.identity}")
+                        self.logger.debug(parsed_data)
                         if recvqueue is not None:
                             # place data on receive queue
                             recvqueue.put((raw_data, parsed_data))
@@ -182,7 +218,7 @@ class GNSSSkeletonApp:
                 RTCMMessageError,
                 RTCMParseError,
             ) as err:
-                print(f"Error parsing data stream {err}")
+                self.logger.critical(f"Error parsing data stream {err}")
                 continue
 
     def _extract_data(self, parsed_data: object):
@@ -193,17 +229,30 @@ class GNSSSkeletonApp:
         """
 
         if hasattr(parsed_data, "fixType"):
-            self.fix = FIXTYPE[parsed_data.fixType]
+            self.fix = FIXTYPE.get(parsed_data.fixType, "NO FIX")
         if hasattr(parsed_data, "carrSoln"):
-            self.fix = f"{self.fix} {CARRSOLN[parsed_data.carrSoln]}"
+            if parsed_data.carrSoln != 0:  # NO RTK
+                self.fix = f"{CARRSOLN.get(parsed_data.carrSoln, self.fix)}"
+        if hasattr(parsed_data, "quality"):
+            self.fix = FIXTYPE_GGA.get(parsed_data.quality, "NO FIX")
         if hasattr(parsed_data, "numSV"):
-            self.siv = parsed_data.numSV
+            self.sip = parsed_data.numSV
         if hasattr(parsed_data, "lat"):
             self.lat = parsed_data.lat
         if hasattr(parsed_data, "lon"):
             self.lon = parsed_data.lon
         if hasattr(parsed_data, "alt"):
             self.alt = parsed_data.alt
+        if hasattr(parsed_data, "HDOP"):
+            self.hdop = parsed_data.HDOP
+        if hasattr(parsed_data, "hDOP"):
+            self.hdop = parsed_data.hDOP
+        if hasattr(parsed_data, "diffAge"):
+            self.diffage = parsed_data.diffAge
+        if hasattr(parsed_data, "lastCorrectionAge"):
+            self.diffage = DIFFAGE_PVT.get(parsed_data.lastCorrectionAge, 0)
+        if hasattr(parsed_data, "diffStation"):
+            self.diffstation = parsed_data.diffStation
         if hasattr(parsed_data, "hMSL"):  # UBX hMSL is in mm
             self.alt = parsed_data.hMSL / 1000
         if hasattr(parsed_data, "sep"):
@@ -214,9 +263,9 @@ class GNSSSkeletonApp:
             unit = 1 if parsed_data.identity == "PUBX00" else 1000
             self.hacc = parsed_data.hAcc / unit
         if self.showstatus:
-            print(
-                f"fix {self.fix}, siv {self.siv}, lat {self.lat},",
-                f"lon {self.lon}, alt {self.alt:.3f} m, hAcc {self.hacc:.3f} m",
+            self.logger.info(
+                f"fix {self.fix}, sip {self.sip}, lat {self.lat}, "
+                f"lon {self.lon}, alt {self.alt:.3f} m, hAcc {self.hacc:.3f} m"
             )
 
     def _send_data(self, stream: Serial, sendqueue: Queue):
@@ -233,10 +282,8 @@ class GNSSSkeletonApp:
                 while not sendqueue.empty():
                     data = sendqueue.get(False)
                     raw_data, parsed_data = data
-                    if self.verbosity == 1:
-                        print(f"GNSS<< {parsed_data.identity}")
-                    elif self.verbosity == 2:
-                        print(parsed_data)
+                    self.logger.info(f"GNSS<< {parsed_data.identity}")
+                    self.logger.debug(f"{parsed_data}")
                     stream.write(raw_data)
                     sendqueue.task_done()
             except Empty:
@@ -268,58 +315,45 @@ class GNSSSkeletonApp:
         Return current receiver navigation solution.
         (method needed by certain pygnssutils classes)
 
-        :return: tuple of (connection status, lat, lon, alt and sep)
+        :return: tuple
         :rtype: tuple
         """
 
-        return (self.connected, self.lat, self.lon, self.alt, self.sep)
+        return (
+            self.connected,
+            self.lat,
+            self.lon,
+            self.alt,
+            self.sep,
+            self.sip,
+            self.fix,
+            self.hdop,
+            self.diffage,
+            self.diffstation,
+        )
 
 
-if __name__ == "__main__":
-    arp = ArgumentParser(
-        formatter_class=ArgumentDefaultsHelpFormatter,
-    )
-    arp.add_argument(
-        "-P", "--port", required=False, help="Serial port", default="/dev/ttyACM1"
-    )
-    arp.add_argument(
-        "-B", "--baudrate", required=False, help="Baud rate", default=38400, type=int
-    )
-    arp.add_argument(
-        "-T", "--timeout", required=False, help="Timeout in secs", default=3, type=float
-    )
-    arp.add_argument(
-        "--verbosity",
-        required=False,
-        help="Verbosity",
-        default=1,
-        choices=[0, 1, 2],
-        type=int,
-    )
-    arp.add_argument(
-        "--enableubx", required=False, help="Enable UBX output", default=1, type=int
-    )
-    arp.add_argument(
-        "--showstatus", required=False, help="Show GNSS status", default=1, type=int
-    )
+def main(**kwargs):
+    """
+    Main routine - CLI entry point.
+    """
 
-    args = arp.parse_args()
     recv_queue = Queue()  # set to None to print data to stdout
     send_queue = Queue()
     stop_event = Event()
 
     try:
-        print("Starting GNSS reader/writer...\n")
+
         with GNSSSkeletonApp(
-            args.port,
-            int(args.baudrate),
-            float(args.timeout),
+            kwargs.get("port", "/dev/ttyACM0"),
+            int(kwargs.get("baudrate", 38400)),
+            float(kwargs.get("timeout", 3)),
             stop_event,
             recvqueue=recv_queue,
             sendqueue=send_queue,
-            verbosity=int(args.verbosity),
-            enableubx=int(args.enableubx),
-            showstatus=int(args.showstatus),
+            verbosity=int(kwargs.get("verbosity", VERBOSITY_MEDIUM)),
+            enableubx=int(kwargs.get("enableubx", 1)),
+            showstatus=int(kwargs.get("showstatus", 1)),
         ) as gna:
             gna.run()
             while True:
@@ -327,4 +361,28 @@ if __name__ == "__main__":
 
     except KeyboardInterrupt:
         stop_event.set()
-        print("Terminated by user")
+
+
+if __name__ == "__main__":
+
+    ap = ArgumentParser(
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    ap.add_argument(
+        "-P", "--port", required=False, help="Serial port", default="/dev/ttyACM1"
+    )
+    ap.add_argument(
+        "-B", "--baudrate", required=False, help="Baud rate", default=38400, type=int
+    )
+    ap.add_argument(
+        "-T", "--timeout", required=False, help="Timeout in secs", default=3, type=float
+    )
+    ap.add_argument(
+        "--enableubx", required=False, help="Enable UBX output", default=1, type=int
+    )
+    ap.add_argument(
+        "--showstatus", required=False, help="Show GNSS status", default=1, type=int
+    )
+    args = set_common_args(ap)
+
+    main(**args)

--- a/examples/gnssdump.conf
+++ b/examples/gnssdump.conf
@@ -1,0 +1,5 @@
+filename=pygpsdata-MIXED3.log
+verbosity=3
+format=2
+clioutput=1
+output=testfile.bin

--- a/examples/rtcm_ntrip_client.py
+++ b/examples/rtcm_ntrip_client.py
@@ -22,11 +22,12 @@ Created on 12 Feb 2023
 :license: BSD 3-Clause
 """
 
+from logging import getLogger
 from os import getenv
 from sys import argv
 from time import sleep
 
-from pygnssutils import GNSSNTRIPClient
+from pygnssutils import VERBOSITY_HIGH, GNSSNTRIPClient, set_logging
 
 DEFAULT_PORT = 2101
 
@@ -36,6 +37,8 @@ def main(**kwargs):
     Main routine.
     """
 
+    logger = getLogger("pygnssutils.gnssntripclient")
+    set_logging(logger, VERBOSITY_HIGH)
     server = kwargs.get("server", "rtk2go.com")
     port = int(kwargs.get("port", DEFAULT_PORT))
     mountpoint = kwargs.get("mountpoint", "")
@@ -48,7 +51,7 @@ def main(**kwargs):
 
         https = 1 if port == 443 else 0
 
-        print(
+        logger.info(
             f"RTCM NTRIP Client started, writing output to {outfile}... Press CTRL-C to terminate."
         )
         gnc.run(
@@ -67,7 +70,7 @@ def main(**kwargs):
             while True:
                 sleep(3)
         except KeyboardInterrupt:
-            print("RTCM NTRIP Client terminated by User")
+            logger.info("RTCM NTRIP Client terminated by User")
 
 
 if __name__ == "__main__":

--- a/examples/rtk_example.py
+++ b/examples/rtk_example.py
@@ -18,7 +18,7 @@ to an RTK-compatible u-blox GNSS receiver (e.g. ZED-F9P)
 connected to a local serial port (USB or UART1).
 
 GNSSNTRIPClient receives RTCM3 or SPARTN data from the NTRIP
-caster and outputs it to a message queue. An example
+caster and outputs it to a message queue. A basic
 GNSSSkeletonApp class reads data from this queue and sends
 it to the receiver, while reading and parsing data from the
 receiver and printing it to the terminal.
@@ -26,6 +26,8 @@ receiver and printing it to the terminal.
 GNSSNtripClient optionally sends NMEA GGA position sentences
 to the caster at a prescribed interval, using either fixed
 reference coordinates or live coordinates from the receiver.
+For NTRIP 2.0 protocol, the first GGA sentence is embedded
+in the HTTP GET request header.
 
 NB: Some NTRIP casters may stop sending RTK data after a while
 if they're not receiving legitimate NMEA GGA position updates

--- a/examples/spartn_decrypt.py
+++ b/examples/spartn_decrypt.py
@@ -35,13 +35,15 @@ from datetime import UTC, datetime
 from os import getenv
 from sys import argv
 
-from pyspartn import SPARTNReader, ERRIGNORE
+from pyspartn import ERRIGNORE, SPARTNReader
 
 
 def main(**kwargs):
     """
     Read, decrypt and decode SPARTN log file.
     """
+
+    # pylint: disable=protected-access
 
     infile = kwargs.get("infile", "d9s_spartn_data.bin")
     key = kwargs.get(

--- a/examples/spartn_mqtt_client.py
+++ b/examples/spartn_mqtt_client.py
@@ -28,13 +28,13 @@ Created on 12 Feb 2023
 """
 
 from datetime import datetime, timezone
-from os import path, getenv
+from logging import getLogger
+from os import getenv, path
 from pathlib import Path
 from sys import argv
 from time import sleep
 
-from pygnssutils import GNSSMQTTClient
-
+from pygnssutils import VERBOSITY_HIGH, GNSSMQTTClient, set_logging
 
 SERVER = "pp.services.u-blox.com"
 PORT = 8883
@@ -45,6 +45,8 @@ def main(**kwargs):
     Main routine.
     """
 
+    logger = getLogger("pygnssutils.gnssmqttclient")
+    set_logging(logger, VERBOSITY_HIGH)
     clientid = kwargs.get("clientid", getenv("MQTTCLIENTID", ""))
     region = kwargs.get("region", "eu")
     decode = int(kwargs.get("decode", 0))
@@ -54,7 +56,7 @@ def main(**kwargs):
     with open(outfile, "wb") as out:
         gmc = GNSSMQTTClient()
 
-        print(f"SPARTN MQTT Client started, writing output to {outfile}...")
+        logger.info(f"SPARTN MQTT Client started, writing output to {outfile}...")
         gmc.start(
             server=SERVER,
             port=PORT,
@@ -76,10 +78,11 @@ def main(**kwargs):
             while True:
                 sleep(3)
         except KeyboardInterrupt:
-            print("SPARTN MQTT Client terminated by User")
-            print(
-                f"To decrypt the contents of the output file {outfile} using pyspartn,",
-                f"use kwargs: decode=True, key=key_supplied_by_service_provider, basedate={repr(datetime.now(timezone.utc))}",
+            logger.info("SPARTN MQTT Client terminated by User")
+            logger.info(
+                f"To decrypt the contents of the output file {outfile} using pyspartn, "
+                f"use kwargs: decode=True, key=key_supplied_by_service_provider, "
+                "basedate={repr(datetime.now(timezone.utc))}",
             )
 
 

--- a/examples/spartn_ntrip_client.py
+++ b/examples/spartn_ntrip_client.py
@@ -28,12 +28,13 @@ Created on 12 Feb 2023
 :license: BSD 3-Clause
 """
 
-from os import path, getenv
+from datetime import datetime, timezone
+from logging import getLogger
+from os import getenv
 from sys import argv
 from time import sleep
-from datetime import datetime, timezone
 
-from pygnssutils import GNSSNTRIPClient
+from pygnssutils import VERBOSITY_HIGH, GNSSNTRIPClient, set_logging
 
 SERVER = "ppntrip.services.u-blox.com"
 PORT = 2102
@@ -45,6 +46,8 @@ def main(**kwargs):
     Main routine.
     """
 
+    logger = getLogger("pygnssutils.gnssntripclient")
+    set_logging(logger, VERBOSITY_HIGH)
     user = kwargs.get("user", getenv("PYGPSCLIENT_USER", "user"))
     password = kwargs.get("password", getenv("PYGPSCLIENT_PASSWORD", "password"))
     decode = int(kwargs.get("decode", 0))
@@ -55,8 +58,9 @@ def main(**kwargs):
     with open(outfile, "wb") as out:
         gnc = GNSSNTRIPClient()
 
-        print(
-            f"SPARTN NTRIP Client started, writing output to {outfile}... Press CTRL-C to terminate."
+        logger.info(
+            "SPARTN NTRIP Client started, writing output "
+            f"to {outfile}... Press CTRL-C to terminate."
         )
         gnc.run(
             server=SERVER,
@@ -77,7 +81,7 @@ def main(**kwargs):
             while True:
                 sleep(3)
         except KeyboardInterrupt:
-            print("SPARTN NTRIP Client terminated by User")
+            logger.info("SPARTN NTRIP Client terminated by User")
 
 
 if __name__ == "__main__":

--- a/examples/ubxsimulator.json
+++ b/examples/ubxsimulator.json
@@ -1,21 +1,21 @@
 {
-	"interval": 1,
+	"interval": 1000,
 	"timeout": 3,
-	"logfile": "/home/myuser/ubxsimulator.log",
+	"logfile": "/Users/steve/ubxsimulator.log",
 	"simVector": 1,
 	"global": {
-		"lat": 52.474715,
-		"lon": 13.403288,
+		"lat": 52.477311,
+		"lon": 13.391426,
 		"alt": 50.034,
 		"height": 47494,
 		"sep": 2.54,
 		"hMSL": 50034,
 		"NS": "N",
 		"EW": "E",
-		"spd": 26.0693,
-		"cog": 125,
-		"gSpeed": 13411,
-		"headMot": 125
+		"gSpeed": 100000,
+		"headMot": 126,
+		"spd": 194.3844,
+		"cog": 126
 	},
 	"ubxmessages": [
 		{

--- a/examples/ubxsimulator.json
+++ b/examples/ubxsimulator.json
@@ -31,7 +31,10 @@
 				"gnssFixOk": 1,
 				"pDOP": 0.843,
 				"hAcc": 585,
-				"vAcc": 543
+				"vAcc": 543,
+				"diffSoln": 1,
+				"carrSoln": 1,
+				"lastCorrectionAge": 5
 			}
 		},
 		{
@@ -241,9 +244,11 @@
 				"navStatus": "V",
 				"sepUnit": "M",
 				"altUnit": "M",
-				"quality": 2,
+				"quality": 5,
 				"numSV": 12,
-				"HDOP": 0.9873476
+				"HDOP": 0.9873476,
+				"diffAge": 10,
+				"diffStation": 2746
 			}
 		},
 		{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.0.31"
+version = "1.0.32"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.31"
+__version__ = "1.0.32"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -11,7 +11,6 @@ Created on 26 May 2022
 CLIAPP = "CLI"
 OUTPORT = 50010
 OUTPORT_NTRIP = 2101
-DEFAULT_TLS_PORTS = (443, 2102)
 MIN_NMEA_PAYLOAD = 3  # minimum viable length of NMEA message payload
 EARTH_RADIUS = 6371  # km
 DEFAULT_BUFSIZE = 4096  # buffer size for NTRIP client
@@ -26,6 +25,7 @@ OUTPUT_NONE = 0
 OUTPUT_FILE = 1
 OUTPUT_SERIAL = 2
 OUTPUT_SOCKET = 3
+OUTPUT_HANDLER = 4
 VERBOSITY_CRITICAL = -1
 VERBOSITY_LOW = 0
 VERBOSITY_MEDIUM = 1
@@ -77,9 +77,14 @@ HTTPCODES = {
     405: "Method Not Allowed",
     406: "Not Acceptable",
     408: "Request Timeout",
+    409: "Conflict",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    501: "Not Implemented",
+    503: "Service Unavailable",
 }
 
-HTTPERR = [f"{i[0]} {i[1]}" for i in HTTPCODES.items() if 400 <= i[0] <= 499]
+HTTPERR = [f"{i[0]} {i[1]}" for i in HTTPCODES.items() if 400 <= i[0] <= 599]
 
 # ranges for ubxsetrate CLI
 ALLNMEA = "allnmea"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -31,6 +31,7 @@ VERBOSITY_LOW = 0
 VERBOSITY_MEDIUM = 1
 VERBOSITY_HIGH = 2
 VERBOSITY_DEBUG = 3
+UBXSIMULATOR = "UBXSIMULATOR"
 LOGGING_LEVELS = {
     VERBOSITY_CRITICAL: "CRITICAL",
     VERBOSITY_LOW: "ERROR",
@@ -59,13 +60,16 @@ GNSSLIST = {
 }
 
 FIXES = {
-    "3D": 1,
-    "2D": 2,
-    "RTK FIXED": 4,
-    "RTK FLOAT": 5,
-    "RTK": 5,
-    "DR": 6,
     "NO FIX": 0,
+    "TIME ONLY": 0,
+    "2D": 1,
+    "3D": 1,
+    "GPS + DR": 1,
+    "GNSS+DR": 1,
+    "RTK": 5,
+    "RTK FLOAT": 5,
+    "RTK FIXED": 4,
+    "DR": 6,
 }
 
 HTTPCODES = {

--- a/src/pygnssutils/gnssdump_cli.py
+++ b/src/pygnssutils/gnssdump_cli.py
@@ -196,7 +196,7 @@ def main():
         ),
         default=None,
     )
-    kwargs = set_common_args(ap)
+    kwargs = set_common_args("gnssdump", ap)
 
     cliout = int(kwargs.pop("clioutput", OUTPUT_NONE))
     try:

--- a/src/pygnssutils/gnssdump_cli.py
+++ b/src/pygnssutils/gnssdump_cli.py
@@ -11,18 +11,39 @@ Created on 24 Jul 2024
 """
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from queue import Queue
+from threading import Thread
+
+from serial import Serial
 
 from pygnssutils._version import __version__ as VERSION
 from pygnssutils.globals import (
     CLIAPP,
     EPILOG,
-    VERBOSITY_CRITICAL,
-    VERBOSITY_DEBUG,
-    VERBOSITY_HIGH,
-    VERBOSITY_LOW,
-    VERBOSITY_MEDIUM,
+    FORMAT_BINARY,
+    FORMAT_HEX,
+    FORMAT_HEXTABLE,
+    FORMAT_JSON,
+    FORMAT_PARSED,
+    FORMAT_PARSEDSTRING,
+    OUTPUT_FILE,
+    OUTPUT_HANDLER,
+    OUTPUT_NONE,
+    OUTPUT_SERIAL,
+    OUTPUT_SOCKET,
 )
 from pygnssutils.gnssstreamer import GNSSStreamer
+from pygnssutils.helpers import set_common_args
+from pygnssutils.socket_server import runserver
+
+
+def runclient(**kwargs):
+    """
+    Start GNSSStreamer with CLI parameters.
+    """
+
+    with GNSSStreamer(CLIAPP, **kwargs) as gns:
+        gns.run()
 
 
 def main():
@@ -74,11 +95,16 @@ def main():
         "--format",
         required=False,
         help=(
-            "Output format 1 = parsed, 2 = binary, 4 = hex, 8 = tabulated hex, "
-            "16 = parsed as string, 32 = JSON (can be OR'd)"
+            f"{FORMAT_PARSED} - parsed as object; "
+            f"{FORMAT_BINARY} - binary (raw); "
+            f"{FORMAT_HEX} - hexadecimal; "
+            f"{FORMAT_HEXTABLE} - tabular hexadecimal; "
+            f"{FORMAT_PARSEDSTRING} - parsed as string; "
+            f"{FORMAT_JSON} - JSON. "
+            f"Options can be OR'd e.g. {FORMAT_PARSED} | {FORMAT_HEXTABLE}."
         ),
         type=int,
-        default=1,
+        default=FORMAT_PARSED,
     )
     ap.add_argument(
         "--validate",
@@ -138,55 +164,70 @@ def main():
         default=0,
     )
     ap.add_argument(
-        "--verbosity",
+        "--clioutput",
         required=False,
         help=(
-            f"Log message verbosity "
-            f"{VERBOSITY_CRITICAL} = critical, "
-            f"{VERBOSITY_LOW} = low (error), "
-            f"{VERBOSITY_MEDIUM} = medium (warning), "
-            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
+            f"CLI output type {OUTPUT_NONE} = none, "
+            f"{OUTPUT_FILE} = binary file, "
+            f"{OUTPUT_SERIAL} = serial port, "
+            f"{OUTPUT_SOCKET} = TCP socket server, "
+            f"{OUTPUT_HANDLER} = evaluable Python expression"
         ),
         type=int,
         choices=[
-            VERBOSITY_CRITICAL,
-            VERBOSITY_LOW,
-            VERBOSITY_MEDIUM,
-            VERBOSITY_HIGH,
-            VERBOSITY_DEBUG,
+            OUTPUT_NONE,
+            OUTPUT_FILE,
+            OUTPUT_SERIAL,
+            OUTPUT_SOCKET,
+            OUTPUT_HANDLER,
         ],
-        default=VERBOSITY_HIGH,
+        default=OUTPUT_NONE,
     )
     ap.add_argument(
-        "--outfile",
+        "--output",
         required=False,
-        help="Fully qualified path to output file",
+        help=(
+            f"Output medium as formatted string. "
+            f"If clioutput = {OUTPUT_FILE}, format = file name (e.g. '/home/myuser/ubxdata.ubx'); "
+            f"If clioutput = {OUTPUT_SERIAL}, format = port@baudrate (e.g. '/dev/tty.ACM0@38400'); "
+            f"If clioutput = {OUTPUT_SOCKET}, format = hostip:port (e.g. '0.0.0.0:50010'); "
+            f"If clioutput = {OUTPUT_HANDLER}, format = evaluable Python expression. "
+            "NB: gnssdump will have exclusive use of any serial or server port."
+        ),
         default=None,
     )
-    ap.add_argument(
-        "--logtofile",
-        required=False,
-        help="fully qualified log file name, or '' for no log file",
-        type=str,
-        default="",
-    )
-    ap.add_argument(
-        "--outputhandler",
-        required=False,
-        help="Either writeable output medium or evaluable expression",
-    )
-    ap.add_argument(
-        "--errorhandler",
-        required=False,
-        help="Either writeable output medium or evaluable expression",
-    )
+    kwargs = set_common_args(ap)
 
-    kwargs = vars(ap.parse_args())
-
+    cliout = int(kwargs.pop("clioutput", OUTPUT_NONE))
     try:
-        with GNSSStreamer(CLIAPP, **kwargs) as gns:
-            gns.run()
-
+        if cliout == OUTPUT_FILE:
+            filename = kwargs["output"]
+            ftyp = "wb" if int(kwargs["format"]) == FORMAT_BINARY else "w"
+            with open(filename, ftyp) as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SERIAL:
+            port, baud = kwargs["output"].split("@")
+            with Serial(port, int(baud), timeout=3) as output:
+                kwargs["output"] = output
+                runclient(**kwargs)
+        elif cliout == OUTPUT_SOCKET:
+            host, port = kwargs["output"].split(":")
+            kwargs["output"] = Queue()
+            # socket server runs as background thread, piping
+            # output from ntrip client via a message queue
+            Thread(
+                target=runserver,
+                args=(host, int(port), kwargs["output"]),
+                daemon=True,
+            ).start()
+            runclient(**kwargs)
+        elif cliout == OUTPUT_HANDLER:
+            kwargs["output"] = eval(kwargs["output"])  # pylint: disable=eval-used
+            runclient(**kwargs)
+        else:
+            kwargs["output"] = None
+            runclient(**kwargs)
     except KeyboardInterrupt:
         pass
 

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -21,10 +21,10 @@ Created on 20 Feb 2023
 
 # pylint: disable=invalid-name
 
-import logging
 import socket
 from datetime import datetime, timezone
 from io import BufferedWriter, BytesIO, TextIOWrapper
+from logging import getLogger
 from os import getenv, path
 from pathlib import Path
 from queue import Queue
@@ -52,15 +52,11 @@ from pygnssutils.globals import (
     TOPIC_DATA,
     TOPIC_FREQ,
     TOPIC_KEY,
-    VERBOSITY_MEDIUM,
 )
-from pygnssutils.helpers import set_logging
 from pygnssutils.mqttmessage import MQTTMessage
 
 TIMEOUT = 8
 DLGTSPARTN = "SPARTN Configuration"
-
-logger = logging.getLogger(__name__)
 
 
 class GNSSMQTTClient:
@@ -73,16 +69,11 @@ class GNSSMQTTClient:
         Constructor.
 
         :param object app: application from which this class is invoked (None)
-        :param int verbosity: (kwarg) log verbosity (1 = medium)
-        :param str logtofile: (kwarg) fully qualifed log file name ('')
         """
 
         self.__app = app  # Reference to calling application class (if applicable)
-        set_logging(
-            logger,
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
-            kwargs.pop("logtofile", ""),
-        )
+        # configure logger with name "pygnssutils" in calling module
+        self.logger = getLogger(__name__)
         self._validargs = True
         clientid = getenv("MQTTCLIENTID", default="enter-client-id")
 
@@ -105,8 +96,6 @@ class GNSSMQTTClient:
 
         self._timeout = kwargs.get("timeout", TIMEOUT)
         self.errevent = kwargs.get("errevent", Event())
-        self._verbosity = int(kwargs.get("verbosity", VERBOSITY_MEDIUM))
-        self._logtofile = int(kwargs.get("logtofile", 0))
         self._logpath = kwargs.get("logpath", ".")
         self._loglines = 0
         self._socket = None
@@ -166,36 +155,43 @@ class GNSSMQTTClient:
         """
 
         try:
-            for kwarg in [
-                "server",
-                "port",
-                "clientid",
-                "region",
-                "mode",
-                "topic_ip",
-                "topic_mga",
-                "topic_key",
-                "tlscrt",
-                "tlskey",
-                "spartndecode",
-                "spartnkey",
-                "spartnbasedate",
-                "output",
-            ]:
-                if kwarg in kwargs:
-                    self._settings[kwarg] = kwargs.get(kwarg)
-            self._verbosity = int(kwargs.get("verbosity", self._verbosity))
-            self._logtofile = int(kwargs.get("logtofile", self._logtofile))
-            self._logpath = kwargs.get("logpath", self._logpath)
+            self._settings["server"] = kwargs.get("server", self._settings["server"])
+            self._settings["port"] = int(kwargs.get("port", self._settings["port"]))
+            self._settings["clientid"] = kwargs.get(
+                "clientid", self._settings["clientid"]
+            )
+            self._settings["region"] = kwargs.get("region", self._settings["region"])
+            self._settings["mode"] = int(kwargs.get("mode", self._settings["mode"]))
+            self._settings["topic_ip"] = int(
+                kwargs.get("topic_ip", self._settings["topic_ip"])
+            )
+            self._settings["topic_mga"] = int(
+                kwargs.get("topic_mga", self._settings["topic_mga"])
+            )
+            self._settings["topic_key"] = int(
+                kwargs.get("topic_key", self._settings["topic_key"])
+            )
+            self._settings["tlscrt"] = kwargs.get("tlscrt", self._settings["tlscrt"])
+            self._settings["tlskey"] = kwargs.get("tlskey", self._settings["tlskey"])
+            self._settings["spartndecode"] = int(
+                kwargs.get("spartndecode", self._settings["spartndecode"])
+            )
+            self._settings["spartnkey"] = kwargs.get(
+                "spartnkey", self._settings["spartnkey"]
+            )
+            self._settings["spartnbasedate"] = kwargs.get(
+                "spartnbasedate", self._settings["spartnbasedate"]
+            )
+            self._settings["output"] = kwargs.get("output", self._settings["output"])
 
         except (ParameterError, ValueError, TypeError) as err:
-            logger.critical(
+            self.logger.critical(
                 f"Invalid input arguments {kwargs}\n{err}\nType gnssntripclient -h for help."
             )
             self._validargs = False
             return 0
 
-        logger.info(f"Starting MQTT client with arguments {self._settings}.")
+        self.logger.info(f"Starting MQTT client with arguments {self._settings}.")
         self._stopevent.clear()
         self._mqtt_thread = Thread(
             target=self._run,
@@ -217,7 +213,7 @@ class GNSSMQTTClient:
 
         self._stopevent.set()
         self._mqtt_thread = None
-        logger.info("MQTT Client Stopped.")
+        self.logger.info("MQTT Client Stopped.")
 
     def _run(
         self,
@@ -256,7 +252,7 @@ class GNSSMQTTClient:
             "decode": settings["spartndecode"],
             "key": settings["spartnkey"],
             "basedate": settings["spartnbasedate"],
-            "verbosity": self._verbosity,
+            "logger": self.logger,
         }
 
         try:
@@ -286,7 +282,7 @@ class GNSSMQTTClient:
                             f"Unable to connect to {settings['server']}"
                             + f":{settings['port']} in {timeout} seconds. {err}"
                         ) from err
-                    logger.info(f"Trying to connect {i} ...")
+                    self.logger.info(f"Trying to connect {i} ...")
                     sleep(timeout / 4)
                     i += 1
 
@@ -296,7 +292,7 @@ class GNSSMQTTClient:
                 # client.loop(timeout=0.1)
                 sleep(0.1)
         except (FileNotFoundError, TimeoutError) as err:
-            logger.critical(f"ERROR! {err}")
+            self.logger.critical(f"ERROR! {err}")
             GNSSMQTTClient.on_error(userdata, err)
             self.stop()
             self.errevent.set()
@@ -358,6 +354,7 @@ class GNSSMQTTClient:
 
         output = userdata["output"]
         app = userdata["app"]
+        msglogger = userdata["logger"]
 
         def do_write(raw: bytes, parsed: object):
             """
@@ -371,8 +368,8 @@ class GNSSMQTTClient:
             """
 
             if hasattr(parsed, "identity"):
-                logger.info(parsed.identity)
-            logger.debug(parsed)
+                msglogger.info(parsed.identity)
+            msglogger.debug(parsed)
 
             if output is not None:
                 if isinstance(output, (Serial, BufferedWriter)):
@@ -422,11 +419,13 @@ class GNSSMQTTClient:
         :param object rcd: return code (int or str)
         """
 
+        errlogger = userdata["logger"]
+
         if isinstance(err, int):
             err = mqtt.error_string(err)
         app = userdata["app"]
         if app is None:
-            logger.error(err)
+            errlogger.error(err)
         else:
             if hasattr(app, "dialog"):
                 dlg = app.dialog(DLGTSPARTN)

--- a/src/pygnssutils/gnssmqttclient_cli.py
+++ b/src/pygnssutils/gnssmqttclient_cli.py
@@ -203,7 +203,7 @@ def main():
         ),
         default=None,
     )
-    kwargs = set_common_args(ap)
+    kwargs = set_common_args("gnssmqttclient", ap)
 
     kwargs["errevent"] = Event()
     cliout = int(kwargs.pop("clioutput", OUTPUT_NONE))

--- a/src/pygnssutils/gnssmqttclient_cli.py
+++ b/src/pygnssutils/gnssmqttclient_cli.py
@@ -30,13 +30,9 @@ from pygnssutils.globals import (
     OUTPUT_SERIAL,
     OUTPUT_SOCKET,
     SPARTN_PPSERVER,
-    VERBOSITY_CRITICAL,
-    VERBOSITY_DEBUG,
-    VERBOSITY_HIGH,
-    VERBOSITY_LOW,
-    VERBOSITY_MEDIUM,
 )
 from pygnssutils.gnssmqttclient import TIMEOUT, GNSSMQTTClient
+from pygnssutils.helpers import set_common_args
 from pygnssutils.socket_server import runserver
 
 TIMEOUT = 8
@@ -48,13 +44,12 @@ def runclient(**kwargs):
     Start MQTT client with CLI parameters.
     """
 
+    waittime = float(kwargs["waittime"])
     with GNSSMQTTClient(CLIAPP, **kwargs) as gsc:
         streaming = gsc.start(**kwargs)
-        while (
-            streaming and not kwargs["errevent"].is_set()
-        ):  # run until error or user presses CTRL-C
-            sleep(kwargs["waittime"])
-        sleep(kwargs["waittime"])
+        while streaming and not kwargs["errevent"].is_set():
+            sleep(waittime)
+        sleep(waittime)
 
 
 def main():
@@ -75,7 +70,7 @@ def main():
     )
     ap.add_argument("-V", "--version", action="version", version="%(prog)s " + VERSION)
     ap.add_argument(
-        "-C",
+        "-I",
         "--clientid",
         required=False,
         help="Client ID",
@@ -170,33 +165,6 @@ def main():
         default=datetime.now(timezone.utc),
     )
     ap.add_argument(
-        "--verbosity",
-        required=False,
-        help=(
-            f"Log message verbosity "
-            f"{VERBOSITY_CRITICAL} = critical, "
-            f"{VERBOSITY_LOW} = low (error), "
-            f"{VERBOSITY_MEDIUM} = medium (warning), "
-            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
-        ),
-        type=int,
-        choices=[
-            VERBOSITY_CRITICAL,
-            VERBOSITY_LOW,
-            VERBOSITY_MEDIUM,
-            VERBOSITY_HIGH,
-            VERBOSITY_DEBUG,
-        ],
-        default=VERBOSITY_MEDIUM,
-    )
-    ap.add_argument(
-        "--logtofile",
-        required=False,
-        help="fully qualified log file name, or '' for no log file",
-        type=str,
-        default="",
-    )
-    ap.add_argument(
         "--waittime",
         required=False,
         help="waitimer",
@@ -209,12 +177,6 @@ def main():
         help="MQTT connection timeout (seconds)",
         type=int,
         default=TIMEOUT,
-    )
-    ap.add_argument(
-        "--errevent",
-        required=False,
-        help="Error event",
-        default=Event(),
     )
     ap.add_argument(
         "--clioutput",
@@ -241,11 +203,10 @@ def main():
         ),
         default=None,
     )
+    kwargs = set_common_args(ap)
 
-    args = ap.parse_args()
-    kwargs = vars(args)
-
-    cliout = kwargs.pop("clioutput", OUTPUT_NONE)
+    kwargs["errevent"] = Event()
+    cliout = int(kwargs.pop("clioutput", OUTPUT_NONE))
     try:
         if cliout == OUTPUT_FILE:
             filename = kwargs["output"]

--- a/src/pygnssutils/gnssntripclient_cli.py
+++ b/src/pygnssutils/gnssntripclient_cli.py
@@ -216,7 +216,7 @@ def main():
         ),
         default=None,
     )
-    kwargs = set_common_args(ap)
+    kwargs = set_common_args("gnssntripclient", ap)
 
     kwargs["ggamode"] = GGAFIXED  # only fixed reference mode is available via CLI
     cliout = int(kwargs.pop("clioutput", OUTPUT_NONE))

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -93,8 +93,9 @@ class GNSSSocketServer:
             self._kwargs["maxclients"] = int(kwargs.get("maxclients", 5))
             self._kwargs["format"] = int(kwargs.get("format", FORMAT_BINARY))
             # required fixed arguments...
-            msgqueue = Queue()
-            self._kwargs["outputhandler"] = msgqueue
+            # msgqueue = Queue()
+            # self._kwargs["outputhandler"] = msgqueue
+            self._kwargs["output"] = Queue()
             self._socket_server = None
             self._streamer = None
             self._in_thread = None
@@ -219,7 +220,7 @@ class GNSSSocketServer:
                 app,
                 kwargs["ntripmode"],
                 kwargs["maxclients"],
-                kwargs["outputhandler"],
+                kwargs["output"],
                 conn,
                 ClientHandler,
                 ntripuser=kwargs["ntripuser"],

--- a/src/pygnssutils/gnssserver.py
+++ b/src/pygnssutils/gnssserver.py
@@ -16,23 +16,15 @@ Created on 24 May 2022
 
 # pylint: disable=too-many-arguments
 
-import logging
+from logging import getLogger
 from queue import Queue
 from threading import Thread
 from time import sleep
 
-from pygnssutils.globals import (
-    CONNECTED,
-    FORMAT_BINARY,
-    OUTPORT,
-    OUTPORT_NTRIP,
-    VERBOSITY_MEDIUM,
-)
+from pygnssutils.globals import CONNECTED, FORMAT_BINARY, OUTPORT, OUTPORT_NTRIP
 from pygnssutils.gnssstreamer import GNSSStreamer
-from pygnssutils.helpers import format_conn, ipprot2int, set_logging
+from pygnssutils.helpers import format_conn, ipprot2int
 from pygnssutils.socket_server import ClientHandler, SocketServer
-
-logger = logging.getLogger(__name__)
 
 
 class GNSSSocketServer:
@@ -69,17 +61,13 @@ class GNSSSocketServer:
         :param int protfilter: (kwarg) 1 = NMEA, 2 = UBX, 4 = RTCM3 (7 - ALL)
         :param str msgfilter: (kwarg) comma-separated string of message identities e.g. 'NAV-PVT,GNGSA' (None)
         :param int limit: (kwarg) maximum number of messages to read (0 = unlimited)
-        :param int verbosity: (kwarg) log message verbosity 0 = low, 1 = medium, 3 = high (1)
-        :param str logtofile: (kwarg) fully qualifed log file name ('')
         """
 
         # Reference to calling application class (if applicable)
         self.__app = app  # pylint: disable=unused-private-member
-        set_logging(
-            logger,
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
-            kwargs.pop("logtofile", ""),
-        )
+        # configure logger with name "pygnssutils" in calling module
+        self.logger = getLogger(__name__)
+        self.logger.debug(kwargs)
         try:
             self._kwargs = kwargs
             # overrideable command line arguments..
@@ -115,7 +103,7 @@ class GNSSSocketServer:
             self._validargs = True
 
         except ValueError as err:
-            logger.critical(f"Invalid input arguments {kwargs}\n{err}")
+            self.logger.critical(f"Invalid input arguments {kwargs}\n{err}")
             self._validargs = False
 
     def __enter__(self):
@@ -143,7 +131,7 @@ class GNSSSocketServer:
         """
 
         if self._validargs:
-            logger.info("Starting server (type CTRL-C to stop)...")
+            self.logger.info("Starting server (type CTRL-C to stop)...")
             self._in_thread = self._start_input_thread(**self._kwargs)
             sleep(0.5)
             if self._in_thread.is_alive():
@@ -158,12 +146,12 @@ class GNSSSocketServer:
         Shutdown server.
         """
 
-        logger.info("Stopping server...")
+        self.logger.info("Stopping server...")
         if self._streamer is not None:
             self._streamer.stop()
         if self._socket_server is not None:
             self._socket_server.shutdown()
-        logger.info("Server shutdown.")
+        self.logger.info("Server shutdown.")
 
     def _start_input_thread(self, **kwargs) -> Thread:
         """
@@ -174,7 +162,7 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        logger.info(f"Starting input thread, reading from {kwargs['port']}...")
+        self.logger.info(f"Starting input thread, reading from {kwargs['port']}...")
         thread = Thread(
             target=self._input_thread,
             args=(kwargs,),
@@ -192,7 +180,7 @@ class GNSSSocketServer:
         :rtype: Thread
         """
 
-        logger.info(
+        self.logger.info(
             f"Starting output thread, broadcasting on {kwargs['hostip']}:{kwargs['outport']}..."
         )
         thread = Thread(
@@ -240,7 +228,7 @@ class GNSSSocketServer:
             ) as self._socket_server:
                 self._socket_server.serve_forever()
         except OSError as err:
-            logger.critical(f"Error starting socket server {err}")
+            self.logger.critical(f"Error starting socket server {err}")
 
     def notify_client(self, address: tuple, status: int):
         """
@@ -257,6 +245,6 @@ class GNSSSocketServer:
         else:
             pre = "dis"
             self._clients -= 1
-        logger.info(
+        self.logger.info(
             f"Client {address} has {pre}connected. Total clients: {self._clients}"
         )

--- a/src/pygnssutils/gnssserver_cli.py
+++ b/src/pygnssutils/gnssserver_cli.py
@@ -177,7 +177,7 @@ def main():
         type=int,
         default=1,
     )
-    kwargs = set_common_args(ap)
+    kwargs = set_common_args("gnssserver", ap)
 
     if kwargs["hostip"] == "0.0.0.0" and kwargs["ipprot"] == "IPv6":
         kwargs["hostip"] = "::"

--- a/src/pygnssutils/gnssserver_cli.py
+++ b/src/pygnssutils/gnssserver_cli.py
@@ -15,16 +15,9 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from time import sleep
 
 from pygnssutils._version import __version__ as VERSION
-from pygnssutils.globals import (
-    CLIAPP,
-    EPILOG,
-    VERBOSITY_CRITICAL,
-    VERBOSITY_DEBUG,
-    VERBOSITY_HIGH,
-    VERBOSITY_LOW,
-    VERBOSITY_MEDIUM,
-)
+from pygnssutils.globals import CLIAPP, EPILOG
 from pygnssutils.gnssserver import GNSSSocketServer
+from pygnssutils.helpers import set_common_args
 
 
 def main():
@@ -172,26 +165,6 @@ def main():
         default=0,
     )
     ap.add_argument(
-        "--verbosity",
-        required=False,
-        help=(
-            f"Log message verbosity "
-            f"{VERBOSITY_CRITICAL} = critical, "
-            f"{VERBOSITY_LOW} = low (error), "
-            f"{VERBOSITY_MEDIUM} = medium (warning), "
-            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
-        ),
-        type=int,
-        choices=[
-            VERBOSITY_CRITICAL,
-            VERBOSITY_LOW,
-            VERBOSITY_MEDIUM,
-            VERBOSITY_HIGH,
-            VERBOSITY_DEBUG,
-        ],
-        default=VERBOSITY_MEDIUM,
-    )
-    ap.add_argument(
         "--outfile",
         required=False,
         help="Fully qualified path to output file",
@@ -204,16 +177,8 @@ def main():
         type=int,
         default=1,
     )
-    ap.add_argument(
-        "--logtofile",
-        required=False,
-        help="fully qualified log file name, or '' for no log file",
-        type=str,
-        default="",
-    )
+    kwargs = set_common_args(ap)
 
-    args = ap.parse_args()
-    kwargs = vars(args)
     if kwargs["hostip"] == "0.0.0.0" and kwargs["ipprot"] == "IPv6":
         kwargs["hostip"] = "::"
 
@@ -222,8 +187,8 @@ def main():
             goodtogo = server.run()
 
             while goodtogo:  # run until user presses CTRL-C
-                sleep(args.waittime)
-            sleep(args.waittime)
+                sleep(kwargs["waittime"])
+            sleep(kwargs["waittime"])
 
     except KeyboardInterrupt:
         pass

--- a/src/pygnssutils/gnssstreamer.py
+++ b/src/pygnssutils/gnssstreamer.py
@@ -5,6 +5,10 @@ GNSSStreamer class - essentially a wrapper around the pyubx2.ubxreader class
 to stream the parsed UBX, NMEA or RTCM3 output of a GNSS device to stdout or
 a designated output handler.
 
+NB: This utility is used by PyGPSClient - do not change footprint of
+any public methods without first checking impact on PyGPSClient -
+https://github.com/semuconsulting/PyGPSClient.
+
 Created on 26 May 2022
 
 :author: semuadmin
@@ -48,8 +52,10 @@ from pygnssutils.globals import (
     FORMAT_JSON,
     FORMAT_PARSED,
     FORMAT_PARSEDSTRING,
+    UBXSIMULATOR,
 )
 from pygnssutils.helpers import format_conn, format_json, ipprot2int
+from pygnssutils.ubxsimulator import UBXSimulator
 
 
 class GNSSStreamer:
@@ -213,10 +219,14 @@ class GNSSStreamer:
             with self._datastream as self._stream:
                 self._start_reader()
         elif self._port is not None:  # serial
-            with Serial(
-                self._port, self._baudrate, timeout=self._timeout
-            ) as self._stream:
-                self._start_reader()
+            if self._port.upper() == UBXSIMULATOR:
+                with UBXSimulator() as self._stream:
+                    self._start_reader()
+            else:
+                with Serial(
+                    self._port, self._baudrate, timeout=self._timeout
+                ) as self._stream:
+                    self._start_reader()
         elif self._socket is not None:  # socket
             with socket(self._ipprot, SOCK_STREAM) as self._stream:
                 self._stream.connect(

--- a/src/pygnssutils/gnssstreamer.py
+++ b/src/pygnssutils/gnssstreamer.py
@@ -14,9 +14,9 @@ Created on 26 May 2022
 
 # pylint: disable=line-too-long eval-used
 
-import logging
 from collections import defaultdict
 from io import BufferedWriter, TextIOWrapper
+from logging import getLogger
 from queue import Queue
 from socket import AF_INET6, SOCK_STREAM, socket
 from time import time
@@ -48,11 +48,8 @@ from pygnssutils.globals import (
     FORMAT_JSON,
     FORMAT_PARSED,
     FORMAT_PARSEDSTRING,
-    VERBOSITY_HIGH,
 )
-from pygnssutils.helpers import format_conn, format_json, ipprot2int, set_logging
-
-logger = logging.getLogger(__name__)
+from pygnssutils.helpers import format_conn, format_json, ipprot2int
 
 
 class GNSSStreamer:
@@ -95,27 +92,22 @@ class GNSSStreamer:
         :param int protfilter: (kwarg) 1 = NMEA, 2 = UBX, 4 = RTCM3 (7 - ALL)
         :param str msgfilter: (kwarg) comma-separated string of message identities e.g. 'NAV-PVT,GNGSA' (None)
         :param int limit: (kwarg) maximum number of messages to read (0 = unlimited)
-        :param int verbosity: (kwarg) log message verbosity 0 = low, 1 = medium, 3 = high (1)
-        :param str outfile: (kwarg) fully qualified path to output file (None)
-        :param str logtofile: (kwarg) fully qualifed log file name ('')
-        :param object outputhandler: (kwarg) either writeable output medium or evaluable expression (None)
-        :param object errorhandler: (kwarg) either writeable output medium or evaluable expression (None)
+        :param object output: (kwarg) either writeable output medium or callback function (None)
         :raises: ParameterError
         """
         # pylint: disable=raise-missing-from
 
         # Reference to calling application class (if applicable)
         self.__app = app  # pylint: disable=unused-private-member
-        set_logging(
-            logger, kwargs.pop("verbosity", VERBOSITY_HIGH), kwargs.pop("logtofile", "")
-        )
+        # configure logger with name "pygnssutils" in calling module
+        self.logger = getLogger(__name__)
         self._reader = None
         self.ctx_mgr = False
         self._datastream = kwargs.get("datastream", None)
         self._port = kwargs.get("port", None)
         self._socket = kwargs.get("socket", None)
-        self._outfile = kwargs.get("outfile", None)
         self._ipprot = ipprot2int(kwargs.get("ipprot", "IPv4"))
+        self._output = kwargs.get("output", None)
 
         if self._socket is not None:
             if self._ipprot == AF_INET6:  # IPv6 host ip must be enclosed in []
@@ -177,49 +169,15 @@ class GNSSStreamer:
             self._outcount = defaultdict(int)
             self._errcount = 0
             self._validargs = True
-            self._output = None
             self._stopevent = False
-            self._outputhandler = None
-            self._errorhandler = None
 
             # flag to signify beginning of JSON array
             self._jsontop = True
-
-            self._setup_output_handlers(**kwargs)
 
         except (ParameterError, ValueError, TypeError) as err:
             raise ParameterError(
                 f"Invalid input arguments {kwargs}\n{err}\nType gnssdump -h for help."
             )
-
-    def _setup_output_handlers(self, **kwargs):
-        """
-        Set up output handlers.
-
-        Output handlers can either be writeable output media
-        (Serial, File, socket or Queue) or an evaluable expression.
-
-        (Note: ast.literal_eval can't replace eval here)
-
-        'allhandler' applies to all protocols and overrides
-        individual output handlers.
-        """
-
-        htypes = (Serial, TextIOWrapper, BufferedWriter, Queue, socket)
-
-        erh = kwargs.get("errorhandler", None)
-        if erh is not None:
-            if isinstance(erh, htypes):
-                self._errorhandler = erh
-            else:
-                self._errorhandler = eval(erh)
-
-        oph = kwargs.get("outputhandler", None)
-        if oph is not None:
-            if isinstance(oph, htypes):
-                self._outputhandler = oph
-            else:
-                self._outputhandler = eval(oph)
 
     def __enter__(self):
         """
@@ -247,10 +205,6 @@ class GNSSStreamer:
         :raises: ParameterError if socket is not in form host:port
         """
         # pylint: disable=consider-using-with
-
-        if self._outfile is not None:
-            ftyp = "wb" if self._format == FORMAT_BINARY else "w"
-            self._output = open(self._outfile, ftyp)
 
         self._limit = int(kwargs.get("limit", self._limit))
 
@@ -294,16 +248,13 @@ class GNSSStreamer:
             f"Messages output:   {dict(sorted(self._outcount.items()))}",
         ]
         for msg in msgs:
-            logger.info(msg)
+            self.logger.info(msg)
 
         msg = (
             f"Streaming terminated, {self._msgcount:,} message{mss} "
             f"processed with {self._errcount:,} error{ers}."
         )
-        logger.info(msg)
-
-        if self._output is not None:
-            self._output.close()
+        self.logger.info(msg)
 
     def _start_reader(self):
         """Create UBXReader instance."""
@@ -316,7 +267,7 @@ class GNSSStreamer:
             msgmode=self._msgmode,
             parsebitfield=self._parsebitfield,
         )
-        logger.info(f"Parsing GNSS data stream from: {self._stream}...")
+        self.logger.info(f"Parsing GNSS data stream from: {self._stream}...")
 
         # if outputting json, add opening tag
         if self._format == FORMAT_JSON:
@@ -361,7 +312,7 @@ class GNSSStreamer:
                     raise EOFError
 
                 # get the message protocol (NMEA or UBX)
-                handler = self._outputhandler
+                handler = self._output
                 msgprot = 0
                 # establish the appropriate handler and identity for this protocol
                 if isinstance(parsed_data, UBXMessage):
@@ -416,7 +367,9 @@ class GNSSStreamer:
                     return False
                 toc = time()
                 elapsed = toc - tic
-                logger.debug(f"Time since last {identity} message was sent: {elapsed}")
+                self.logger.debug(
+                    f"Time since last {identity} message was sent: {elapsed}"
+                )
                 # check if at least 95% of filter period has elapsed
                 if elapsed >= 0.95 * per:
                     self._msgfilter[identity] = (per, toc)
@@ -426,8 +379,8 @@ class GNSSStreamer:
 
     def _do_output(self, raw: bytes, parsed: object, handler: object):
         """
-        Output message to terminal in specified format(s) OR pass
-        to external output handler if one is specified.
+        Output message to stdout in specified format(s) OR pass
+        to writeable output media / callback function if specified.
 
         :param bytes raw: raw (binary) message
         :param object parsed: parsed message
@@ -471,51 +424,31 @@ class GNSSStreamer:
             handler.put(output)
         elif isinstance(handler, socket):
             handler.sendall(output)
-        # treated as evaluable expression
+        # callback function
         else:
             handler(output)
 
     def _do_print(self, data: object):
         """
-        Print data to outfile or stdout.
+        Print data to stdout.
 
         :param object data: data to print
         """
 
-        if self._outfile is None:
-            print(data)
-        else:
-            if (self._format == FORMAT_BINARY and not isinstance(data, bytes)) or (
-                self._format != FORMAT_BINARY and not isinstance(data, str)
-            ):
-                data = f"{data}\n"
-            self._output.write(data)
+        print(data)
 
     def _do_error(self, err: Exception):
         """
         Handle error according to quitonerror flag;
-        either ignore, log, (re)raise or pass to
-        external error handler if one is specified.
+        either ignore, log, or (re)raise.
 
         :param err Exception: error
         """
 
-        if self._errorhandler is None:
-            if self._quitonerror == ERR_RAISE:
-                raise err
-            if self._quitonerror == ERR_LOG:
-                logger.critical(err)
-        elif isinstance(self._errorhandler, (Serial, BufferedWriter)):
-            self._errorhandler.write(err)
-        elif isinstance(self._errorhandler, TextIOWrapper):
-            self._errorhandler.write(str(err))
-        elif isinstance(self._errorhandler, Queue):
-            self._errorhandler.put(err)
-        elif isinstance(self._errorhandler, socket):
-            self._errorhandler.sendall(err)
-        else:
-            self._errorhandler(err)
-        self._errcount += 1
+        if self._quitonerror == ERR_RAISE:
+            raise err
+        if self._quitonerror == ERR_LOG:
+            self.logger.critical(err)
 
     def _do_json(self, parsed: object) -> str:
         """
@@ -547,7 +480,7 @@ class GNSSStreamer:
         else:
             cap = "]}"
 
-        oph = self._outputhandler
+        oph = self._output
         if oph is None:
             print(cap)
         elif isinstance(oph, (Serial, TextIOWrapper, BufferedWriter)):

--- a/src/pygnssutils/helpers.py
+++ b/src/pygnssutils/helpers.py
@@ -14,6 +14,7 @@ import logging
 import logging.handlers
 from argparse import ArgumentParser
 from math import cos, radians, sin
+from os import getenv
 from socket import AF_INET, AF_INET6, gaierror, getaddrinfo
 
 from pynmeagps import haversine
@@ -52,6 +53,7 @@ def parse_config(configfile: str) -> dict:
 
 
 def set_common_args(
+    name: str,
     ap: ArgumentParser,
     logname: str = "pygnssutils",
     logdefault: int = VERBOSITY_MEDIUM,
@@ -59,6 +61,7 @@ def set_common_args(
     """
     Set common argument parser and logging args.
 
+    :param str name: name of CLI utility e.g. "gnssdump"
     :param ArgumentParserap: argument parser instance
     :param str logname: logger name
     :param int logdefault: default logger verbosity level
@@ -70,8 +73,11 @@ def set_common_args(
         "-C",
         "--config",
         required=False,
-        help="Fully qualified path to CLI configuration file",
-        default=None,
+        help=(
+            "Fully qualified path to CLI configuration file "
+            f"(will use environment variable {name.upper()}_CONF where set)"
+        ),
+        default=getenv(f"{name.upper()}_CONF", None),
     )
     ap.add_argument(
         "--verbosity",

--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -21,6 +21,10 @@ arguments or set as environment variables:
 export PYGPSCLIENT_USER="user"
 export PYGPSCLIENT_PASSWORD="password"
 
+NB: This utility is used by PyGPSClient - do not change footprint of
+any public methods without first checking impact on PyGPSClient -
+https://github.com/semuconsulting/PyGPSClient.
+
 Created on 16 May 2022
 
 :author: semuadmin

--- a/src/pygnssutils/ubxsave.py
+++ b/src/pygnssutils/ubxsave.py
@@ -51,24 +51,11 @@ from serial import Serial
 
 from pygnssutils._version import __version__ as VERSION
 from pygnssutils.globals import EPILOG
+from pygnssutils.helpers import progbar
 
 # try increasing these values if device response is too slow:
 DELAY = 0.02  # delay between polls
 WRAPUP = 5  # delay for final responses
-
-
-def progbar(i: int, lim: int, inc: int = 50):
-    """
-    Display progress bar on console.
-    """
-
-    i = min(i, lim)
-    pct = int(i * inc / lim)
-    if not i % int(lim / inc):
-        print(
-            f"{int(pct*100/inc):02}% " + "\u2593" * pct + "\u2591" * (inc - pct),
-            end="\r",
-        )
 
 
 class UBXSaver:

--- a/src/pygnssutils/ubxsimulator.py
+++ b/src/pygnssutils/ubxsimulator.py
@@ -9,7 +9,7 @@ Simulates a GNSS serial stream by generating synthetic UBX or NMEA messages
 based on parameters defined in a json configuration file. Can simulate a
 motion vector based on a specified course over ground and speed.
 
-Example usage::
+Example usage:
 
     from pygnssutils import UBXSimulator
     from pyubx2 import UBXReader
@@ -39,9 +39,9 @@ Created on 3 Feb 2024
 
 # pylint: disable=too-many-locals, too-many-instance-attributes
 
-import logging
 from datetime import datetime, timedelta
 from json import JSONDecodeError, load
+from logging import getLogger
 from math import cos, pi, sin
 from os import path
 from pathlib import Path
@@ -50,25 +50,26 @@ from threading import Event, Thread
 from time import sleep
 
 from pynmeagps import NMEAMessage
+from pyrtcm import RTCMMessage, RTCMMessageError, RTCMParseError, RTCMReader
 from pyubx2 import (
     GET,
+    RTCM3_PROTOCOL,
+    UBX_PROTOCOL,
     UBXMessage,
     UBXMessageError,
     UBXParseError,
     UBXReader,
     escapeall,
     getinputmode,
+    protocol,
     utc2itow,
 )
 
-from pygnssutils.globals import EARTH_RADIUS, VERBOSITY_MEDIUM
-from pygnssutils.helpers import set_logging
+from pygnssutils.globals import EARTH_RADIUS
 
 DEFAULT_INTERVAL = 1000  # milliseconds
 DEFAULT_TIMEOUT = 3  # seconds
 DEFAULT_PATH = path.join(Path.home(), "ubxsimulator")
-
-logger = logging.getLogger(__name__)
 
 
 class UBXSimulator:
@@ -87,16 +88,13 @@ class UBXSimulator:
 
         # Reference to calling application class (if applicable)
         self.__app = app  # pylint: disable=unused-private-member
-        set_logging(
-            logger,
-            kwargs.pop("verbosity", VERBOSITY_MEDIUM),
-            kwargs.pop("logtofile", ""),
-        )
+        # configure logger with name "pygnssutils" in calling module
+        self.logger = getLogger(__name__)
         self._config = self._readconfig(
             kwargs.get("configfile", DEFAULT_PATH + ".json")
         )
         self._logfile = self._config.get("logfile", DEFAULT_PATH + ".log")
-        logger.info(f"Configuration loaded:\n{self._config}")
+        self.logger.debug(f"Configuration loaded:\n{self._config}")
         self._interval = kwargs.get(
             "interval", (self._config.get("interval", DEFAULT_INTERVAL))
         )  # milliseconds
@@ -125,7 +123,7 @@ class UBXSimulator:
             with open(cfile, "r", encoding="utf-8") as jsonfile:
                 config = load(jsonfile)
         except (OSError, JSONDecodeError) as err:
-            logger.error(f"Unable to read configuration file:\n{err}")
+            self.logger.error(f"Unable to read configuration file:\n{err}")
             return {
                 "interval": DEFAULT_INTERVAL,
                 "timeout": DEFAULT_TIMEOUT,
@@ -154,7 +152,7 @@ class UBXSimulator:
         Start streaming.
         """
 
-        logger.info("UBX Simulator started")
+        self.logger.info("UBX Simulator started")
         self._stopevent.clear()
         self._msgfactory_thread = Thread(
             target=self._msgfactory,
@@ -187,7 +185,7 @@ class UBXSimulator:
             self._mainloop_thread.join()
         if self._msgfactory_thread is not None:
             self._msgfactory_thread.join()
-        logger.info("UBX Simulator stopped")
+        self.logger.info("UBX Simulator stopped")
 
     def _mainloop(self, stop: Event, outq: Queue, inq: Queue):
         """
@@ -204,7 +202,7 @@ class UBXSimulator:
                 outq.task_done()
             while not inq.empty():
                 data = inq.get()
-                self._ubxhandler(data, outq)
+                self._datahandler(data, outq)
                 inq.task_done()
             sleep(self._interval / 10000)
 
@@ -282,26 +280,27 @@ class UBXSimulator:
             sleep(self._interval / 1000)
             loops = (loops + 1) % 1024
 
-    def _ubxhandler(self, data: UBXMessage, outq: Queue):
+    def _datahandler(self, data: bytes, outq: Queue):
         """
         THREADED
-        Process incoming UBX data.
+        Process incoming UBX or RTCM3 data.
 
         TODO enhance to mimic wider range of command or poll responses.
 
-        :param bytes data: UBXMessage
+        :param bytes data: UBXMessage or RTCMMessage
         :param Queue outq: output queue
         """
 
         if data is None:
             return
 
-        self._do_ackack(data, outq)
+        if isinstance(data, UBXMessage):
+            self._do_ackack(data, outq)
 
-        if data.identity == "MON-VER":
-            self._do_monver(outq)
-        if data.identity == "CFG-RATE":
-            self._do_cfgrate(data, outq)
+            if data.identity == "MON-VER":
+                self._do_monver(outq)
+            if data.identity == "CFG-RATE":
+                self._do_cfgrate(data, outq)
 
     def _do_send(self, msg: UBXMessage, outq: Queue):
         """
@@ -313,7 +312,7 @@ class UBXSimulator:
 
         raw = msg.serialize()
         outq.put(raw)
-        logger.info(f"Response Sent by Simulator:\n{raw}\n{msg}")
+        self.logger.info(f"Response Sent by Simulator:\n{raw}\n{msg}")
 
     def _do_ackack(self, data: UBXMessage, outq: Queue):
         """
@@ -436,21 +435,55 @@ class UBXSimulator:
         :param bytes data: UBX data
         """
 
+        prot = protocol(data)
         try:
-            msgmode = getinputmode(data)  # returns SET or POLL
-            ubx = UBXReader.parse(data, msgmode=msgmode)
-            self._inqueue.put(ubx)
-            val = ("Valid UBX", ubx)
-        except (UBXParseError, UBXMessageError) as err:
+            if prot == RTCM3_PROTOCOL:
+                rtm = RTCMReader.parse(data)
+                self._inqueue.put(rtm)
+                val = ("RTCM", rtm)
+            elif prot == UBX_PROTOCOL:
+                msgmode = getinputmode(data)  # returns SET or POLL
+                ubx = UBXReader.parse(data, msgmode=msgmode)
+                self._inqueue.put(ubx)
+                val = ("UBX", ubx)
+            else:
+                val = (f"Other Protocol {prot}", None)
+        except (
+            UBXParseError,
+            UBXMessageError,
+            RTCMParseError,
+            RTCMMessageError,
+        ) as err:
             val = ("Invalid/Unknown Data:", f"{err}")
-        logger.info(
+        self.logger.debug(
             f"{val[0]} Data Received by Simulator:\n{escapeall(data)}\n{val[1]}"
         )
 
+    def close(self):
+        """
+        Close dummy serial stream.
+        """
+
+        self.stop()
+
     @property
-    def is_open(self):
+    def is_open(self) -> bool:
         """
         Return status.
+
+        :return: true or false
+        :rtype: bool
         """
 
         return self._mainloop_thread is not None
+
+    @property
+    def in_waiting(self) -> int:
+        """
+        Return number of bytes in buffer.
+
+        :return: buffer length
+        :rtype: int
+        """
+
+        return len(self._buffer)

--- a/src/pygnssutils/ubxsimulator.py
+++ b/src/pygnssutils/ubxsimulator.py
@@ -43,7 +43,7 @@ from datetime import datetime, timedelta
 from json import JSONDecodeError, load
 from logging import getLogger
 from math import cos, pi, sin
-from os import path
+from os import getenv, path
 from pathlib import Path
 from queue import Queue
 from threading import Event, Thread
@@ -65,7 +65,7 @@ from pyubx2 import (
     utc2itow,
 )
 
-from pygnssutils.globals import EARTH_RADIUS
+from pygnssutils.globals import EARTH_RADIUS, UBXSIMULATOR
 
 DEFAULT_INTERVAL = 1000  # milliseconds
 DEFAULT_TIMEOUT = 3  # seconds
@@ -91,9 +91,11 @@ class UBXSimulator:
         # configure logger with name "pygnssutils" in calling module
         self.logger = getLogger(__name__)
         self._config = self._readconfig(
-            kwargs.get("configfile", DEFAULT_PATH + ".json")
+            kwargs.get(
+                "configfile",
+                getenv(f"{UBXSIMULATOR.upper()}_JSON", DEFAULT_PATH + ".json"),
+            )
         )
-        self._logfile = self._config.get("logfile", DEFAULT_PATH + ".log")
         self.logger.debug(f"Configuration loaded:\n{self._config}")
         self._interval = kwargs.get(
             "interval", (self._config.get("interval", DEFAULT_INTERVAL))

--- a/src/pygnssutils/ubxsimulator_cli.py
+++ b/src/pygnssutils/ubxsimulator_cli.py
@@ -21,13 +21,13 @@ from pygnssutils.globals import CLIAPP, EPILOG, UBXSIMULATOR
 from pygnssutils.helpers import set_common_args
 from pygnssutils.ubxsimulator import DEFAULT_PATH, UBXSimulator
 
+SIMCONFIG = f"{UBXSIMULATOR.upper()}_JSON"
+
 
 def main():
     """
     CLI Entry point.
     """
-
-    SIMCONFIG = f"{UBXSIMULATOR.upper()}_JSON"
 
     ap = ArgumentParser(
         description="pygnssutils EXPERIMENTAL UBX Serial Device Simulator",

--- a/src/pygnssutils/ubxsimulator_cli.py
+++ b/src/pygnssutils/ubxsimulator_cli.py
@@ -11,19 +11,13 @@ Created on 24 Jul 2024
 """
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from logging import getLogger
 
 from pyubx2 import UBXReader
 
 from pygnssutils._version import __version__ as VERSION
-from pygnssutils.globals import (
-    CLIAPP,
-    EPILOG,
-    VERBOSITY_CRITICAL,
-    VERBOSITY_DEBUG,
-    VERBOSITY_HIGH,
-    VERBOSITY_LOW,
-    VERBOSITY_MEDIUM,
-)
+from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.helpers import set_common_args
 from pygnssutils.ubxsimulator import DEFAULT_PATH, UBXSimulator
 
 
@@ -43,8 +37,8 @@ def main():
         "--interval",
         required=False,
         type=float,
-        help="Simulated navigation interval in seconds (Hz = 1/interval)",
-        default=1,
+        help="Simulated navigation interval in milliseconds (Hz = 1000/interval)",
+        default=1000,
     )
     ap.add_argument(
         "-T",
@@ -55,53 +49,27 @@ def main():
         default=3,
     )
     ap.add_argument(
-        "-C",
-        "--configfile",
+        "--simconfigfile",
         required=False,
         type=str,
-        help="Fully qualified path to json configuration file",
+        help="Fully qualified path to simulator json configuration file",
         default=DEFAULT_PATH + ".json",
     )
-    ap.add_argument(
-        "--verbosity",
-        required=False,
-        help=(
-            f"Log message verbosity "
-            f"{VERBOSITY_CRITICAL} = critical, "
-            f"{VERBOSITY_LOW} = low (error), "
-            f"{VERBOSITY_MEDIUM} = medium (warning), "
-            f"{VERBOSITY_HIGH} = high (info), {VERBOSITY_DEBUG} = debug"
-        ),
-        type=int,
-        choices=[
-            VERBOSITY_CRITICAL,
-            VERBOSITY_LOW,
-            VERBOSITY_MEDIUM,
-            VERBOSITY_HIGH,
-            VERBOSITY_DEBUG,
-        ],
-        default=VERBOSITY_MEDIUM,
-    )
-    ap.add_argument(
-        "--logtofile",
-        required=False,
-        help="fully qualified log file name, or '' for no log file",
-        type=str,
-        default="",
-    )
+    kwargs = set_common_args(ap)
 
-    kwargs = vars(ap.parse_args())
+    logger = getLogger("pygnssutils.ubxsimulator")
 
+    kwargs["configfile"] = kwargs.pop("simconfigfile", DEFAULT_PATH + ".json")
     with UBXSimulator(CLIAPP, **kwargs) as stream:
 
         try:
             ubr = UBXReader(stream)
             i = 0
             for _, parsed in ubr:
-                print(parsed)
+                logger.debug(str(parsed))
                 i += 1
         except KeyboardInterrupt:
-            print(f"Terminated by user, {i} messages read")
+            logger.info(f"Terminated by user, {i} messages processed")
 
 
 if __name__ == "__main__":

--- a/src/pygnssutils/ubxsimulator_cli.py
+++ b/src/pygnssutils/ubxsimulator_cli.py
@@ -12,11 +12,12 @@ Created on 24 Jul 2024
 
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 from logging import getLogger
+from os import getenv
 
 from pyubx2 import UBXReader
 
 from pygnssutils._version import __version__ as VERSION
-from pygnssutils.globals import CLIAPP, EPILOG
+from pygnssutils.globals import CLIAPP, EPILOG, UBXSIMULATOR
 from pygnssutils.helpers import set_common_args
 from pygnssutils.ubxsimulator import DEFAULT_PATH, UBXSimulator
 
@@ -25,6 +26,8 @@ def main():
     """
     CLI Entry point.
     """
+
+    SIMCONFIG = f"{UBXSIMULATOR.upper()}_JSON"
 
     ap = ArgumentParser(
         description="pygnssutils EXPERIMENTAL UBX Serial Device Simulator",
@@ -52,14 +55,19 @@ def main():
         "--simconfigfile",
         required=False,
         type=str,
-        help="Fully qualified path to simulator json configuration file",
-        default=DEFAULT_PATH + ".json",
+        help=(
+            "Fully qualified path to simulator json configuration file "
+            f"(will use environment variable {SIMCONFIG} if set)"
+        ),
+        default=getenv(SIMCONFIG, DEFAULT_PATH + ".json"),
     )
-    kwargs = set_common_args(ap)
+    kwargs = set_common_args("ubxsimulator", ap)
 
     logger = getLogger("pygnssutils.ubxsimulator")
 
-    kwargs["configfile"] = kwargs.pop("simconfigfile", DEFAULT_PATH + ".json")
+    kwargs["configfile"] = kwargs.pop(
+        "simconfigfile", getenv(SIMCONFIG, DEFAULT_PATH + ".json")
+    )
     with UBXSimulator(CLIAPP, **kwargs) as stream:
 
         try:

--- a/tests/gnssdump.conf
+++ b/tests/gnssdump.conf
@@ -1,0 +1,5 @@
+filename=pygpsdata-MIXED3.log
+verbosity=3
+format=2
+clioutput=1
+output=testfile.bin

--- a/tests/test_gnssdump.py
+++ b/tests/test_gnssdump.py
@@ -161,7 +161,7 @@ class GNSSDumpTest(unittest.TestCase):
             protfilter=2,
             msgfilter="NAV-PVT",
             limit=2,
-            outputhandler="lambda msg: print(f'lat: {msg.lat}, lon: {msg.lon}')",
+            output=eval("lambda msg: print(f'lat: {msg.lat}, lon: {msg.lon}')"),
         )
         gns.run()
         sys.stdout = saved_stdout
@@ -181,18 +181,18 @@ class GNSSDumpTest(unittest.TestCase):
         sys.stdout = saved_stdout
         print(f"output = {out.getvalue().strip()}")
 
-    def testgnssdump_outfile(self):
-        saved_stdout = sys.stdout
-        out = StringIO()
-        sys.stdout = out
-        gns = GNSSStreamer(
-            filename=self.mixedfile,
-            format=FORMAT_PARSED,
-            outfile=self.outfilename,
-        )
-        gns.run()
-        sys.stdout = saved_stdout
-        print(f"output = {out.getvalue().strip()}")
+    # def testgnssdump_outfile(self):
+    #     saved_stdout = sys.stdout
+    #     out = StringIO()
+    #     sys.stdout = out
+    #     gns = GNSSStreamer(
+    #         filename=self.mixedfile,
+    #         format=FORMAT_PARSED,
+    #         outfile=self.outfilename,
+    #     )
+    #     gns.run()
+    #     sys.stdout = saved_stdout
+    #     print(f"output = {out.getvalue().strip()}")
 
     # def testgnssdump_outputhandler_file1(self):
 
@@ -217,7 +217,7 @@ class GNSSDumpTest(unittest.TestCase):
             gns = GNSSStreamer(
                 filename=self.mixedfile,
                 format=FORMAT_PARSEDSTRING,
-                outputhandler=ofile,
+                output=ofile,
             )
             gns.run()
             sys.stdout = saved_stdout
@@ -231,7 +231,7 @@ class GNSSDumpTest(unittest.TestCase):
             gns = GNSSStreamer(
                 filename=self.mixedfile,
                 format=FORMAT_BINARY,
-                outputhandler=ofile,
+                output=ofile,
             )
             gns.run()
             sys.stdout = saved_stdout
@@ -245,7 +245,7 @@ class GNSSDumpTest(unittest.TestCase):
             gns = GNSSStreamer(
                 filename=self.mixedfile,
                 format=FORMAT_HEX,
-                outputhandler=ofile,
+                output=ofile,
             )
             gns.run()
             sys.stdout = saved_stdout
@@ -259,7 +259,7 @@ class GNSSDumpTest(unittest.TestCase):
             gns = GNSSStreamer(
                 filename=self.mixedfile,
                 format=FORMAT_HEXTABLE,
-                outputhandler=ofile,
+                output=ofile,
             )
             gns.run()
             sys.stdout = saved_stdout
@@ -273,7 +273,7 @@ class GNSSDumpTest(unittest.TestCase):
             gns = GNSSStreamer(
                 filename=self.mixedfile,
                 format=FORMAT_JSON,
-                outputhandler=ofile,
+                output=ofile,
             )
             gns.run()
             sys.stdout = saved_stdout

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -10,6 +10,8 @@ Created on 26 May 2022
 
 # pylint: disable=line-too-long, invalid-name, missing-docstring, no-member
 
+from os import path
+from pathlib import Path
 import unittest
 from socket import AF_INET, AF_INET6
 from pyubx2 import UBXReader, itow2utc
@@ -22,6 +24,7 @@ from pygnssutils.helpers import (
     ipprot2str,
     format_json,
     get_mp_distance,
+    parse_config,
 )
 from pygnssutils.mqttmessage import MQTTMessage
 from tests.test_sourcetable import TESTSRT
@@ -180,6 +183,17 @@ class StaticTest(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             MQTTMessage(topic, payload=b"arsebiscuits")
+
+    def testparseconfig(self):
+        EXPECTED_RESULT = {
+            "filename": "pygpsdata-MIXED3.log",
+            "verbosity": "3",
+            "format": "2",
+            "clioutput": "1",
+            "output": "testfile.bin",
+        }
+        cfg = parse_config(path.join(path.dirname(__file__), "gnssdump.conf"))
+        self.assertEqual(cfg, EXPECTED_RESULT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

ENHANCEMENTS:

1. Add configuration file option to all CLI utilities via `-C` or `--config` argument. Default location of configuration file can be specified in environment variable `{utility}_CONF` e.g. `GNSSDUMP_CONF`, `GNSSNTRIPCLIENT_CONF`, etc. Config files are text files containing key-value pairs which mirror the existing CLI arguments, e.g. 
```shell
gnssdump -C gnssdump.conf
```
where gnssdump.conf contains...

    filename=pygpsdata-MIXED3.log
    verbosity=3
    format=2
    clioutput=1
    output=testfile.bin

is equivalent to: 
```shell
gnssdump --filename pygpsdata-MIXED3.log --verbosity 3 --format 2 --clioutput 1 --output testfile.bin
```
2. Streamline logging. CLI usage unchanged; to use pygnssutils logging within calling application, invoke `logging.getLogger("pygnssutils")` in calling module.
3. Internal enhancements to experimental UBXSimulator to add close() and in_waiting() methods; recognise incoming RTCM data.
4. GGA message sent to NTRIP Caster in GGALIVE mode will include additional live attributes (siv, hdop, quality, diffage, diffstation). Thanks to @yydgis for contribution.

FIXES:

1. gnssntripclient - update HTTP GET request for better NTRIP 2.0 compliance
1. issue with delay on gnssntripclient retry limit

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
