### PR TITLE
Rc 1.1.7

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,5 @@
     "python.defaultInterpreterPath": "python3",
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.1.6"
+    "moduleversion": "1.1.7"
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 
 ENHANCEMENTS:
 
+1. gnssntripclient will now tolerate an NTRIP 1.0 response to an NTRIP 2.0 request if the caster only supports NTRIP 1.0, or vice versa.
 1. gnssstreamer now supports both NTRIP 1.0 and NTRIP 2.0 clients via the `-rtkntripversion` flag (previously it assumed NTRIP 2.0).
 
 ### RELEASE 1.1.6

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pygnssutils Release Notes
 
+### RELEASE 1.1.7
+
+ENHANCEMENTS:
+
+1. gnssstreamer now supports both NTRIP 1.0 and NTRIP 2.0 clients via the `-rtkntripversion` flag (previously it assumed NTRIP 2.0).
+
 ### RELEASE 1.1.6
 
 FIXES:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pygnssutils"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "GNSS Command Line Utilities"
-version = "1.1.6"
+version = "1.1.7"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -893,8 +893,8 @@ class GNSSNTRIPClient:
         :rtype: bool
         """
 
-        return (self._ntrip_version == NTRIP2 and self.content_type == "gnss/data") or (
-            self._ntrip_version == NTRIP1 and self.status["protocol"].lower() == "icy"
+        return (
+            self.content_type == "gnss/data" or self.status["protocol"].upper() == "ICY"
         )
 
     @property
@@ -907,10 +907,8 @@ class GNSSNTRIPClient:
         """
 
         return (
-            self._ntrip_version == NTRIP2 and self.content_type == "gnss/sourcetable"
-        ) or (
-            self._ntrip_version == NTRIP1
-            and self.status["protocol"].lower() == "sourcetable"
+            self.content_type == "gnss/sourcetable"
+            or self.status["protocol"].upper() == "SOURCETABLE"
         )
 
     @property

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -60,7 +60,6 @@ from pygnssutils.globals import (
     HTTPCODES,
     MAXPORT,
     NOGGA,
-    NTRIP1,
     NTRIP2,
     NTRIP_EVENT,
     OUTPORT_NTRIP,

--- a/src/pygnssutils/gnssstreamer_cli.py
+++ b/src/pygnssutils/gnssstreamer_cli.py
@@ -138,6 +138,7 @@ def _setup_input_ntrip(app: object, datatype: str, **kwargs) -> object:
         mountpoint=path,
         ntripuser=kwargs.get("rtkuser", "anon"),
         ntrippassword=kwargs.get("rtkpassword", "password"),
+        version=kwargs.get("rtkntripversion", "2.0"),
         ggamode=0,
         ggainterval=kwargs.get("rtkggaint", -1),
         datatype=datatype,
@@ -582,6 +583,13 @@ def main():
         required=False,
         help="Password for RTK service (if --cliinput = 1, 2 or 3).",
         default="password",
+    )
+    ap.add_argument(
+        "--rtkntripversion",
+        required=False,
+        help="NTRIP version (if --cliinput = 1)",
+        choices=["1.0", "2.0"],
+        default="2.0",
     )
     ap.add_argument(
         "--rtkggaint",


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. gnssntripclient will now tolerate an NTRIP 1.0 response to an NTRIP 2.0 request if the caster only supports NTRIP 1.0, or vice versa.
1. gnssstreamer now supports both NTRIP 1.0 and NTRIP 2.0 clients via the `-rtkntripversion` flag (previously it assumed NTRIP 2.0).

Fixes #102

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested for range of NTRIP 1.0 and NTRIP 2.0 casters.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
