### PR TITLE
RC 1.1.13

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # pygnssu
 
+### RELEASE 1.1.13
+
+FIXES:
+
+1. Fix issue in GNSSNTRIPClient with parsing some NTRIP responses (missing sourcetable elements).
+
+CHANGES:
+
+1. GNSSMQTTClient add explicit LBand Frequencies topic (`"/pp/frequencies/Lb"`) argument (rather than defaulting to yes if mode is LBand).
+1. New global variable `RTCMTYPES` listing message types and rates output in NTRIP caster mode.
+
 ### RELEASE 1.1.12
 
 FIXES:

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.12"
+__version__ = "1.1.13"

--- a/src/pygnssutils/globals.py
+++ b/src/pygnssutils/globals.py
@@ -170,6 +170,22 @@ HTTPCODES = {
 
 HTTPERR = [f"{i[0]} {i[1]}" for i in HTTPCODES.items() if 400 <= i[0] <= 599]
 
+RTCMTYPES = {
+    "1002": 1,
+    "1006": 5,
+    "1010": 1,
+    "1077": 1,
+    "1087": 1,
+    "1097": 1,
+    "1127": 1,
+    "1230": 1,
+    "4072_0": 1,
+    "4072_1": 1,
+}
+"""RTCM3 message types output in NTRIP caster mode"""
+PYGPSMP = "pygnssutils"
+"""Name of NTRIP caster mountpoint"""
+
 # ranges for ubxsetrate CLI
 ALLNMEA = "allnmea"
 ALLUBX = "allubx"

--- a/src/pygnssutils/gnssmqttclient.py
+++ b/src/pygnssutils/gnssmqttclient.py
@@ -105,6 +105,7 @@ class GNSSMQTTClient:
             "topic_ip": 1,
             "topic_mga": 1,
             "topic_key": 1,
+            "topic_freq": 0,
             "tlscrt": getenv(
                 "MQTTCRT",
                 default=path.join(Path.home(), f"device-{clientid}-pp-cert.crt"),
@@ -196,6 +197,9 @@ class GNSSMQTTClient:
             self._settings["topic_key"] = int(
                 kwargs.get("topic_key", self._settings["topic_key"])
             )
+            self._settings["topic_freq"] = int(
+                kwargs.get("topic_freq", self._settings["topic_freq"])
+            )
             self._settings["tlscrt"] = kwargs.get("tlscrt", self._settings["tlscrt"])
             self._settings["tlskey"] = kwargs.get("tlskey", self._settings["tlskey"])
             self._settings["spartndecode"] = int(
@@ -268,7 +272,7 @@ class GNSSMQTTClient:
             topics.append((TOPIC_ASSIST, 0))
         if settings["topic_key"]:
             topics.append((TOPIC_KEY.format(mode), 0))
-        if mode == "Lb":
+        if settings["topic_freq"]:
             topics.append((TOPIC_FREQ, 0))
         userdata = {
             "output": settings["output"],

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -365,7 +365,7 @@ class GNSSNTRIPClient:
             if len(data) == 0:
                 break
             if response_header:
-                data = self._parse_response_header(data)
+                self._response_body = self._parse_response_header(data)
                 response_header = False
             else:
                 if self.is_gnssdata:
@@ -382,7 +382,7 @@ class GNSSNTRIPClient:
                         output,
                     )
                 else:  # sourcetable
-                    self._response_body = self._response_body + data
+                    self._response_body += data
 
         if not self.responseok:
             msg = (
@@ -479,7 +479,7 @@ class GNSSNTRIPClient:
             if len(rsp) > 1:
                 self._response_headers[rsp[0].lower().strip()] = rsp[1].strip()
         self.logger.debug(
-            f"Response: {self._response_status}\n{self._response_headers}"
+            f"Response Headers and Body: {self._response_headers=} {bdy=}"
         )
         return bdy
 
@@ -562,7 +562,7 @@ class GNSSNTRIPClient:
         :rtype: list
         """
 
-        self.logger.info(f"Sourcetable:\n{response}")
+        self.logger.info(f"Sourcetable:\n{response=}")
         sourcetable = []
         response = response.split("\r\n")
         for line in response:

--- a/src/pygnssutils/gnssstreamer.py
+++ b/src/pygnssutils/gnssstreamer.py
@@ -523,7 +523,7 @@ class GNSSStreamer:
                     if logger is not None:
                         logger.debug(f"Data input: {data}")
                     if isinstance(data, tuple):
-                        raw, info = data
+                        raw, info = data  # pylint:disable=unused-variable
                     else:
                         raw = data
                         info = ""

--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -49,6 +49,8 @@ from pygnssutils.globals import (
     ENV_NTRIP_USER,
     MAXCONNECTION,
     NTRIP2,
+    PYGPSMP,
+    RTCMTYPES,
 )
 from pygnssutils.helpers import ipprot2int
 
@@ -58,7 +60,6 @@ RTCM = b"rtcm"
 SRT = b"srt"
 BAD = b"bad"
 BUFSIZE = 1024
-PYGPSMP = "pygnssutils"
 
 
 class SocketServer(ThreadingTCPServer):
@@ -426,13 +427,16 @@ class ClientHandler(StreamRequestHandler):
         lat, lon = self.server.latlon
         ipaddr, port = self.server.server_address
         pygu = PYGPSMP.upper()
+        rtm = ""
+        for i, (key, val) in enumerate(RTCMTYPES.items()):
+            rtm += f"{key}({val}){',' if i < len(RTCMTYPES)-1 else ''}"
+
         # sourcetable based on ZED-F9P capabilities
         sourcetable = (
             f"CAS;{ipaddr};{port};{PYGPSMP}/{VERSION};SEMU;0;GBR;{lat};{lon};0.0.0.0;0;none\r\n"
             f"NET;{pygu};SEMU;B;N;none;none;none;none\r\n"
-            f"STR;{PYGPSMP};{pygu};RTCM 3.3;"
-            "1005(5),1077(1),1087(1),1097(1),1127(1),1230(1);"
-            f"2;GPS+GLO+GAL+BEI;{pygu};GBR;{lat};{lon};0;0;{pygu};none;B;N;0;\r\n"
+            f"STR;{PYGPSMP};{pygu};RTCM 3.3;{rtm};"
+            f"2;GPS+GLO+GAL+BDS;{pygu};GBR;{lat};{lon};0;0;{pygu};none;B;N;0;\r\n"
             "ENDSOURCETABLE\r\n"
         )
         if self.server.ntripversion == "1.0":


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

FIXES:

1. Fix issue in GNSSNTRIPClient with parsing some NTRIP responses (missing gnss or sourcetable elements at beginning of stream).

CHANGES:

1. GNSSMQTTClient add explicit LBand Frequencies topic (`"/pp/frequencies/Lb"`) argument (rather than defaulting to 'yes' if mode is LBand).
1. New global variable `RTCMTYPES` listing RTCM3 message types and rates output in pygnssutils NTRIP server mode.
1. RTCM 1002 (GPS observables) and 1010 (GLONASS observables) messages added to NTRIP server mode.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] tested against various NTRIP Casters including pygnssutils

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
