### PR TITLE
fix SocketServer allow_reuse_addr

### DIFF
--- a/src/pygnssutils/socket_server.py
+++ b/src/pygnssutils/socket_server.py
@@ -109,8 +109,8 @@ class SocketServer(ThreadingTCPServer):
             self.clientqueues.append({"client": None, "queue": Queue()})
         self._start_read_thread()
         self.daemon_threads = True  # stops deadlock on abrupt termination
-        super().__init__(*args, **kwargs)
         self.allow_reuse_address = True
+        super().__init__(*args, **kwargs)
 
     def server_close(self):
         """


### PR DESCRIPTION
allow_reuse_addr should be set before initialization of the server/socket. Otherwise the socket is created without SO_REUSEADDR.

# pygnssutils Pull Request

## Description

allow_reuse_addr is set to late and the socket is already being created without SO_REUSEADDR.

Fixes #116

Sometimes `gnssstreamer` failed to restart because the port was "in use".

## Testing

Tested the SO_REUSEADDR bit manually with and without change. Tested with gnssstreamer.

```
import socket
print(self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR))
```

## Checklist:

- [x ] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [ x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x ] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [ x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
