### PR TITLE
fix critical error from socket timeout for Python <3.10

### DIFF
--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -262,6 +262,7 @@ class GNSSNTRIPClient:
                 ConnectionResetError,
                 OverflowError,
                 socket.gaierror,
+                socket.timeout,
                 TimeoutError,
             ) as err:
                 errm = str(repr(err))


### PR DESCRIPTION
Starting with Python 3.10 socket.timeout is an alias for TimeoutError instead of a subclass of OSError.

This patch makes the behaviour uniform across supported versions.

# pygnssutils

## Description

Add socket.timeout to the list of non-critical exceptions in the NTRIP client _read_thread.

Fixes #118 

## Checklist:

- [x ] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [ x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [ x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x ] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
