### PR TITLE
Rc 1.1.16

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,13 @@
 
 FIXES:
 
-1. gnssstreamer Fix allow_reuse_addr setting #115
+1. Fix gnssntripclient inappropriate critical error for socket.timeout in Python<3.9 Fixes #118
+
+### RELEASE 1.1.15
+
+FIXES:
+
+1. gnssstreamer Fix allow_reuse_addr setting Fixes #115
 
 ### RELEASE 1.1.14
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,14 @@
 # pygnssutils
 
-### RELEASE 1.1.15
+### RELEASE 1.1.16
 
 FIXES:
 
 1. Fix gnssntripclient inappropriate critical error for socket.timeout in Python<3.9 Fixes #118
+
+CHANGES:
+
+1. Min versions of pyubx2 and pysbf2 updated. 
 
 ### RELEASE 1.1.15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "paho-mqtt>=2.1.0",
     "pyserial>=3.5",
     "pyspartn>=1.0.7",
-    "pyubx2>=1.2.54",
+    "pyubx2>=1.2.55",
     "pysbf2>=1.0.0",
     "pyubxutils>=1.0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "paho-mqtt>=2.1.0",
     "pyserial>=3.5",
     "pyspartn>=1.0.7",
-    "pyubx2>=1.2.53",
+    "pyubx2>=1.2.54",
     "pysbf2>=1.0.0",
     "pyubxutils>=1.0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pyserial>=3.5",
     "pyspartn>=1.0.7",
     "pyubx2>=1.2.53",
-    "pysbf2>=0.2.0",
+    "pysbf2>=1.0.0",
     "pyubxutils>=1.0.3",
 ]
 

--- a/src/pygnssutils/_version.py
+++ b/src/pygnssutils/_version.py
@@ -8,4 +8,4 @@ Created on 2 Oct 2020
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.15"
+__version__ = "1.1.16"

--- a/src/pygnssutils/gnssntripclient.py
+++ b/src/pygnssutils/gnssntripclient.py
@@ -262,6 +262,7 @@ class GNSSNTRIPClient:
                 ConnectionResetError,
                 OverflowError,
                 socket.gaierror,
+                socket.timeout,  # subclass of OSError in Python<=3.9
                 TimeoutError,
             ) as err:
                 errm = str(repr(err))


### PR DESCRIPTION
# pygnssutils Pull Request Template

## Description

1. Fix gnssntripclient inappropriate critical error for socket.timeout in Python<3.9
2. Update minimum pysbf2 version to 1.0.0
3. Update minimum pyubx2 version to 1.2.55

Fixes #118

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested with NTRIP caster on Python 3.9

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygnssutils/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pygnssutils/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] (*if appropriate*) I have cited my u-blox documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
